### PR TITLE
Fix bug where keyNode is nil

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/losisin/helm-values-schema-json
-    rev: v1.0.0
+    rev: v1.1.0
     hooks:
       - id: helm-schema
         args:

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023 Aleksandar Stojanov
+Copyright (c) 2023 - 2024 Aleksandar Stojanov
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ First [install pre-commit](https://pre-commit.com/#install) and then create or u
 ```yaml
 repos:
   - repo: https://github.com/losisin/helm-values-schema-json
-    rev: v1.0.0
+    rev: v1.1.0
     hooks:
       - id: helm-schema
         args: ["-input", "values.yaml"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,42 @@ replicaCount: # @schema type:[integer, null]
 }
 ```
 
+Another way to use this is to define type when using anchors and pointers in yaml. See discussion [#28](https://github.com/losisin/helm-values-schema-json/issues/28) for more details.
+
+```yaml
+app: &app
+  settings:
+    namespace:
+      - *app # @schema type:[string]
+```
+
+```json
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "app": {
+            "properties": {
+                "settings": {
+                    "properties": {
+                        "namespace": {
+                            "items": {
+                                "type": [
+                                    "string"
+                                ]
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "type": "object"
+}
+```
+
 ### Enum
 
 Always returns array of strings. Special case is `null` where instead of string, it is treated as valid inpput type.  [section 6.1.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.2)

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@ replicaCount: # @schema type:[integer, null]
 }
 ```
 
-Another way to use this is to define type when using anchors and pointers in yaml. See discussion [#28](https://github.com/losisin/helm-values-schema-json/issues/28) for more details.
+Another way to use this is to define type when using anchors and aliases in yaml. See discussion [#28](https://github.com/losisin/helm-values-schema-json/issues/28) for more details.
 
 ```yaml
 app: &app

--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -68,10 +68,13 @@ func getSchemaURL(draft int) (string, error) {
 }
 
 func getComment(keyNode *yaml.Node, valNode *yaml.Node) string {
-	if len(valNode.Value) > 0 {
+	if valNode.LineComment != "" {
 		return valNode.LineComment
 	}
-	return keyNode.LineComment
+	if keyNode != nil {
+		return keyNode.LineComment
+	}
+	return ""
 }
 
 func processList(comment string, stringsOnly bool) []interface{} {
@@ -102,8 +105,6 @@ func processComment(schema *Schema, comment string) (isRequired bool) {
 			value := strings.TrimSpace(keyValue[1])
 
 			switch key {
-			case "type":
-				schema.Type = processList(value, true)
 			case "enum":
 				schema.Enum = processList(value, false)
 			case "multipleOf":
@@ -154,6 +155,8 @@ func processComment(schema *Schema, comment string) (isRequired bool) {
 				if strings.TrimSpace(value) == "true" {
 					isRequired = strings.TrimSpace(value) == "true"
 				}
+			case "type":
+				schema.Type = processList(value, true)
 			}
 		}
 	}

--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -203,10 +203,7 @@ func parseNode(keyNode *yaml.Node, valNode *yaml.Node) (*Schema, bool) {
 		}
 	}
 
-	propIsRequired := false
-	if keyNode != nil {
-		propIsRequired = processComment(schema, getComment(keyNode, valNode))
-	}
+	propIsRequired := processComment(schema, getComment(keyNode, valNode))
 
 	return schema, propIsRequired
 }

--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -161,7 +161,7 @@ func TestGetComment(t *testing.T) {
 				Value:       "some value",
 				LineComment: "",
 			},
-			expectedComment: "",
+			expectedComment: "# Key comment",
 		},
 		{
 			name: "empty value node, key node with comment",

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "schema"
-version: "1.0.0"
+version: "1.1.0"
 usage: "generate values.schema.json from values yaml"
 description: "Helm plugin for generating values.schema.json from multiple values files."
 ignoreFlags: false

--- a/testdata/anchors.schema.json
+++ b/testdata/anchors.schema.json
@@ -14,9 +14,7 @@
                             "type": "array"
                         }
                     },
-                    "type": [
-                        "integer"
-                    ]
+                    "type": "object"
                 }
             },
             "type": "object"

--- a/testdata/anchors.schema.json
+++ b/testdata/anchors.schema.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "app": {
+            "properties": {
+                "settings": {
+                    "properties": {
+                        "namespace": {
+                            "items": {
+                                "type": [
+                                    "string"
+                                ]
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": [
+                        "integer"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "type": "object"
+}

--- a/testdata/anchors.yaml
+++ b/testdata/anchors.yaml
@@ -1,4 +1,4 @@
-app: &app # @schema type:[integer]
+app: &app
   settings:
     namespace:
       - *app # @schema type:[string]

--- a/testdata/anchors.yaml
+++ b/testdata/anchors.yaml
@@ -1,0 +1,4 @@
+app: &app # @schema type:[integer]
+  settings:
+    namespace:
+      - *app # @schema type:[string]


### PR DESCRIPTION
If `KeyNode` is `nil`, read from comments anyway.
Closes https://github.com/losisin/helm-values-schema-json/issues/28