### PR TITLE
feat: introduce new flag 'noAdditionalProperties' to add 'additionalProperties: false' to the generated JSON schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ usage: helm schema [-input STR] [-draft INT] [-output STR]
     	Draft version (4, 6, 7, 2019, or 2020) (default 2020)
   -input value
     	Multiple yamlFiles as inputs (comma-separated)
+  -noAdditionalProperties
+        Set this flag to disallow additional properties
   -output string
     	Output file path (default "values.schema.json")
 ```

--- a/pkg/cmd.go
+++ b/pkg/cmd.go
@@ -16,6 +16,7 @@ func ParseFlags(progname string, args []string) (config *Config, output string, 
 	flags.Var(&conf.input, "input", "Multiple yaml files as inputs (comma-separated)")
 	flags.StringVar(&conf.outputPath, "output", "values.schema.json", "Output file path")
 	flags.IntVar(&conf.draft, "draft", 2020, "Draft version (4, 6, 7, 2019, or 2020)")
+	flags.BoolVar(&conf.noAdditionalProperties, "noAdditionalProperties", false, "Set this flag to disallow additional properties")
 
 	err = flags.Parse(args)
 	if err != nil {

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -52,9 +52,10 @@ func GenerateJsonSchema(config *Config) error {
 
 		// Create a temporary Schema to merge from the nodes
 		tempSchema := &Schema{
-			Type:       "object",
-			Properties: properties,
-			Required:   required,
+			Type:                 "object",
+			Properties:           properties,
+			Required:             required,
+			AdditionalProperties: &config.noAdditionalProperties,
 		}
 
 		// Merge with existing data
@@ -63,7 +64,7 @@ func GenerateJsonSchema(config *Config) error {
 	}
 
 	// Convert merged Schema into a JSON Schema compliant map
-	jsonSchemaMap, err := convertSchemaToMap(mergedSchema)
+	jsonSchemaMap, err := convertSchemaToMap(mergedSchema, config.noAdditionalProperties)
 	if err != nil {
 		return err
 	}

--- a/pkg/parser_test.go
+++ b/pkg/parser_test.go
@@ -257,7 +257,7 @@ func TestConvertSchemaToMap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := convertSchemaToMap(tt.schema)
+			got, err := convertSchemaToMap(tt.schema, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("convertSchemaToMap() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -304,7 +304,7 @@ func TestConvertSchemaToMapFail(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := convertSchemaToMap(tc.schema)
+			_, err := convertSchemaToMap(tc.schema, false)
 			tc.expectedErr(t, err)
 		})
 	}

--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -9,24 +9,25 @@ import (
 )
 
 type Schema struct {
-	Type          interface{}        `json:"type,omitempty"`
-	Enum          []any              `json:"enum,omitempty"`
-	MultipleOf    *float64           `json:"multipleOf,omitempty"`
-	Maximum       *float64           `json:"maximum,omitempty"`
-	Minimum       *float64           `json:"minimum,omitempty"`
-	MaxLength     *uint64            `json:"maxLength,omitempty"`
-	MinLength     *uint64            `json:"minLength,omitempty"`
-	Pattern       string             `json:"pattern,omitempty"`
-	MaxItems      *uint64            `json:"maxItems,omitempty"`
-	MinItems      *uint64            `json:"minItems,omitempty"`
-	UniqueItems   bool               `json:"uniqueItems,omitempty"`
-	MaxProperties *uint64            `json:"maxProperties,omitempty"`
-	MinProperties *uint64            `json:"minProperties,omitempty"`
-	Required      []string           `json:"required,omitempty"`
-	Items         *Schema            `json:"items,omitempty"`
-	Properties    map[string]*Schema `json:"properties,omitempty"`
-	Title         string             `json:"title,omitempty"`
-	ReadOnly      bool               `json:"readOnly,omitempty"`
+	Type                 interface{}        `json:"type,omitempty"`
+	Enum                 []any              `json:"enum,omitempty"`
+	MultipleOf           *float64           `json:"multipleOf,omitempty"`
+	Maximum              *float64           `json:"maximum,omitempty"`
+	Minimum              *float64           `json:"minimum,omitempty"`
+	MaxLength            *uint64            `json:"maxLength,omitempty"`
+	MinLength            *uint64            `json:"minLength,omitempty"`
+	Pattern              string             `json:"pattern,omitempty"`
+	MaxItems             *uint64            `json:"maxItems,omitempty"`
+	MinItems             *uint64            `json:"minItems,omitempty"`
+	UniqueItems          bool               `json:"uniqueItems,omitempty"`
+	MaxProperties        *uint64            `json:"maxProperties,omitempty"`
+	MinProperties        *uint64            `json:"minProperties,omitempty"`
+	Required             []string           `json:"required,omitempty"`
+	Items                *Schema            `json:"items,omitempty"`
+	Properties           map[string]*Schema `json:"properties,omitempty"`
+	Title                string             `json:"title,omitempty"`
+	ReadOnly             bool               `json:"readOnly,omitempty"`
+	AdditionalProperties *bool              `json:"additionalProperties,omitempty"`
 }
 
 func getKind(value string) string {

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -4,9 +4,10 @@ import "strings"
 
 // Save values of parsed flags in Config
 type Config struct {
-	input      multiStringFlag
-	outputPath string
-	draft      int
+	input                  multiStringFlag
+	outputPath             string
+	draft                  int
+	noAdditionalProperties bool
 
 	args []string
 }


### PR DESCRIPTION
Implements #38 

- Introduces a new command-line flag `noAdditionalProperties`
- Extended the Config for the new flag
- Extended the Schema for `additionalProperties` to be added to all nodes
- Update Usage section in README
