### PR TITLE
Set Items type in array with schema annotation

### DIFF
--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -172,6 +172,10 @@ func processComment(schema *Schema, comment string) (isRequired bool) {
 				if err := json.Unmarshal([]byte(value), &jsonObject); err == nil {
 					schema.Default = jsonObject
 				}
+			case "item":
+				schema.Items = &Schema{
+					Type: value,
+				}
 			}
 		}
 	}

--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -297,8 +297,8 @@ func TestProcessComment(t *testing.T) {
 		{
 			name:             "Set array",
 			schema:           &Schema{},
-			comment:          "# @schema minItems:1;maxItems:10;uniqueItems:true",
-			expectedSchema:   &Schema{MinItems: uint64Ptr(1), MaxItems: uint64Ptr(10), UniqueItems: true},
+			comment:          "# @schema minItems:1;maxItems:10;uniqueItems:true;item:boolean",
+			expectedSchema:   &Schema{MinItems: uint64Ptr(1), MaxItems: uint64Ptr(10), UniqueItems: true, Items: &Schema{Type: "boolean"}},
 			expectedRequired: false,
 		},
 		{

--- a/testdata/full.schema.json
+++ b/testdata/full.schema.json
@@ -111,6 +111,12 @@
             ],
             "type": "object"
         },
+        "imagePullSecrets": {
+            "items": {
+                "type": "object"
+            },
+            "type": "array"
+        },
         "nameOverride": {
             "type": "string"
         },

--- a/testdata/full.yaml
+++ b/testdata/full.yaml
@@ -18,6 +18,8 @@ replicas: 2 # @schema minimum: 1 ; maximum: 10 ; multipleOf: 2
 fullnameOverride: bar # @schema pattern: ^[a-z]$ ; title: My title
 
 # Arrays
+imagePullSecrets: [] # @schema item: object
+
 tolerations: # @schema minItems: 1 ; maxItems: 10 ; uniqueItems: true
   - key: "bar"
     operator: "Equal"


### PR DESCRIPTION
Current behaviour is to read Items type only when array is not empty recursively from go types. Now it is possible to set Items type with schema annotation in comment.  Useful when array is empty but want to control the types accepted in array. 

closes #48  