### PR TITLE
Add: option to apply enum on array items

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ The following annotations are supported:
     * [Type](#type)
     * [Multiple types](#multiple-types)
     * [Enum](#enum)
+    * [ItemEnum](#itemEnum)
 * [Strings](#strings)
     * [maxLength](#maxlength)
     * [minLength](#minlength)
@@ -120,7 +121,7 @@ Always returns array of strings. Special case is `null` where instead of string,
 ```yaml
 service: ClusterIP # @schema enum:[ClusterIP, LoadBalancer, null]
 ```
-    
+
 ```json
 "service": {
     "enum": [
@@ -129,6 +130,31 @@ service: ClusterIP # @schema enum:[ClusterIP, LoadBalancer, null]
         null
     ],
     "type": "string"
+}
+```
+
+### ItemEnum
+
+This is a special key that apply [enum](#enum) on items of an array.
+
+```yaml
+port: [80, 443] # @schema itemEnum:[80, 8080, 443, 8443]
+```
+
+```json
+"port": {
+    "items": {
+        "type": "number",
+        "enum": [
+            "80",
+            "443",
+            "8080",
+            "8443"
+        ]
+    },
+    "type": [
+        "array"
+    ]
 }
 ```
 
@@ -193,7 +219,7 @@ Number greater than `0`. [section 6.2.1](https://json-schema.org/draft/2020-12/j
 ```yaml
 replicas: 2 # @schema multipleOf:2
 ```
- 
+
 ```json
 "replicas": {
     "multipleOf": 2,
@@ -208,7 +234,7 @@ Number. [section 6.2.2](https://json-schema.org/draft/2020-12/json-schema-valida
 ```yaml
 replicas: 2 # @schema maximum:10
 ```
- 
+
 ```json
 "replicas": {
     "maximum": 10,
@@ -223,7 +249,7 @@ Number. [section 6.2.4](https://json-schema.org/draft/2020-12/json-schema-valida
 ```yaml
 replicas: 5 # @schema minimum:2
 ```
- 
+
 ```json
 "replicas": {
     "minimum": 2,

--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -26,6 +26,7 @@ type Schema struct {
 	PatternProperties    interface{}        `json:"patternProperties,omitempty"`
 	Required             []string           `json:"required,omitempty"`
 	Items                *Schema            `json:"items,omitempty"`
+	ItemsEnum            []any              `json:"itemsEnum,omitempty"`
 	Properties           map[string]*Schema `json:"properties,omitempty"`
 	Title                string             `json:"title,omitempty"`
 	Description          string             `json:"description,omitempty"`
@@ -187,6 +188,11 @@ func processComment(schema *Schema, comment string) (isRequired bool) {
 				schema.Items = &Schema{
 					Type: value,
 				}
+			case "itemEnum":
+				if schema.Items == nil {
+					schema.Items = &Schema{}
+				}
+				schema.Items.Enum = processList(value, false)
 			case "additionalProperties":
 				if v, err := strconv.ParseBool(value); err == nil {
 					schema.AdditionalProperties = &v

--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -302,10 +302,17 @@ func TestProcessComment(t *testing.T) {
 			expectedRequired: false,
 		},
 		{
-			name:             "Set array item enum",
+			name:             "Set array only item enum",
 			schema:           &Schema{},
-			comment:          "# @schema minItems:1;maxItems:10;uniqueItems:true;item:boolean;itemEnum:[\"one\",\"two\"]",
-			expectedSchema:   &Schema{MinItems: uint64Ptr(1), MaxItems: uint64Ptr(10), UniqueItems: true, Items: &Schema{Type: "boolean", Enum: []any{"one", "two"}}},
+			comment:          "# @schema itemEnum:[1,2]",
+			expectedSchema:   &Schema{Items: &Schema{Enum: []any{"1", "2"}}},
+			expectedRequired: false,
+		},
+		{
+			name:             "Set array item type and enum",
+			schema:           &Schema{},
+			comment:          "# @schema minItems:1;maxItems:10;uniqueItems:true;item:string;itemEnum:[\"one\",\"two\"]",
+			expectedSchema:   &Schema{MinItems: uint64Ptr(1), MaxItems: uint64Ptr(10), UniqueItems: true, Items: &Schema{Type: "string", Enum: []any{"one", "two"}}},
 			expectedRequired: false,
 		},
 		{

--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -302,6 +302,13 @@ func TestProcessComment(t *testing.T) {
 			expectedRequired: false,
 		},
 		{
+			name:             "Set array item enum",
+			schema:           &Schema{},
+			comment:          "# @schema minItems:1;maxItems:10;uniqueItems:true;item:boolean;itemEnum:[\"one\",\"two\"]",
+			expectedSchema:   &Schema{MinItems: uint64Ptr(1), MaxItems: uint64Ptr(10), UniqueItems: true, Items: &Schema{Type: "boolean", Enum: []any{"one", "two"}}},
+			expectedRequired: false,
+		},
+		{
 			name:             "Set object",
 			schema:           &Schema{},
 			comment:          "# @schema minProperties:1;maxProperties:10;additionalProperties:false;$id:https://example.com/schema",


### PR DESCRIPTION
This commit introduces a new feature that allows specifying enum values for array items in the JSON schema using the `itemEnum` annotation.

Changes:
- Update the `Schema` struct in `schema.go` to include a new `ItemsEnum` field to store the enum values for array items.
- Modify the `processComment` function in `schema.go` to handle the `item_enum` annotation and assign the enum values to the `Enum` field of the `Items` schema.

With this feature, users can now define enum values for array items in their YAML files using the `itemEnum` annotation, and the generated JSON schema will include the enum values within the `items` section.

Example:

```
# values.yaml
capacityType: ["one","two"] # @schema type:[array];default:["one","two"];minItems:1;itemEnum:["one","two"]
```

Generated JSON for this value will look like
```
"capacityType": {
    "default": [
        "one",
        "two"
    ],
    "items": {
        "type": "string",
        "enum": [
            "one",
            "two"
        ]
    },
    "minItems": 1,
    "type": [
        "array"
    ]
}
```