### PR TITLE
chore: add option to skip properties for a node

### DIFF
--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -33,6 +33,7 @@ type Schema struct {
 	ReadOnly             bool               `json:"readOnly,omitempty"`
 	Default              interface{}        `json:"default,omitempty"`
 	AdditionalProperties *bool              `json:"additionalProperties"`
+	SkipProperties       bool               `json:"skipProperties,omitempty"`
 	ID                   string             `json:"$id,omitempty"`
 }
 
@@ -125,6 +126,10 @@ func processComment(schema *Schema, comment string) (isRequired bool) {
 			case "maximum":
 				if v, err := strconv.ParseFloat(value, 64); err == nil {
 					schema.Maximum = &v
+				}
+			case "skipProperties":
+				if v, err := strconv.ParseBool(value); err == nil && v {
+					schema.SkipProperties = true
 				}
 			case "minimum":
 				if v, err := strconv.ParseFloat(value, 64); err == nil {
@@ -246,6 +251,9 @@ func parseNode(keyNode *yaml.Node, valNode *yaml.Node) (*Schema, bool) {
 	}
 
 	propIsRequired := processComment(schema, getComment(keyNode, valNode))
+	if schema.SkipProperties {
+		schema.Properties = nil
+	}
 
 	return schema, propIsRequired
 }

--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -329,6 +329,13 @@ func TestProcessComment(t *testing.T) {
 			expectedSchema:   &Schema{Title: "My Title", Description: "some description", ReadOnly: false, Default: "foo"},
 			expectedRequired: false,
 		},
+		{
+			name:             "Set skipProperties",
+			schema:           &Schema{},
+			comment:          "# @schema skipProperties:true",
+			expectedSchema:   &Schema{SkipProperties: true},
+			expectedRequired: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/testdata/full.schema.json
+++ b/testdata/full.schema.json
@@ -125,6 +125,9 @@
             },
             "type": "array"
         },
+        "labels": {
+            "type": "object"
+        },
         "nameOverride": {
             "type": "string"
         },

--- a/testdata/full.yaml
+++ b/testdata/full.yaml
@@ -26,6 +26,10 @@ tolerations: # @schema minItems: 1 ; maxItems: 10 ; uniqueItems: true
     value: "baz"
     effect: "NoSchedule"
 
+labels:  # @schema skipProperties:true
+  hello: world
+  foo: bar
+
 # Objects
 affinity:
   nodeAffinity: # @schema minProperties: 1 ; maxProperties: 2 ; additionalProperties: false


### PR DESCRIPTION
@losisin Would you interested in merging a feature like this ?

Usecase:
```
labels:
  default:
    app.k8s.io:/name: abc
    app.k8s.io/namespace: def
```

Ideally, in this case I would only want labels.default to be an object, and not have any  properties as the yaml is completely a user input blob, and can have any properties

So adding `skipProperties: true` here would not those in schema     