### PR TITLE
feat: introduce flag noAdditionalProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Usage: helm schema [options...] <arguments>
     	Multiple yaml files as inputs (comma-separated)
   -output string
     	Output file path (default "values.schema.json")
+  -noAdditionalProperties value
+         Default additionalProperties to false for all objects in the schema (true/false)
   -schemaRoot.additionalProperties value
     	JSON schema additional properties (true/false)
   -schemaRoot.description string

--- a/pkg/cmd.go
+++ b/pkg/cmd.go
@@ -20,6 +20,7 @@ func ParseFlags(progname string, args []string) (*Config, string, error) {
 	flags.StringVar(&conf.OutputPath, "output", "values.schema.json", "Output file path")
 	flags.IntVar(&conf.Draft, "draft", 2020, "Draft version (4, 6, 7, 2019, or 2020)")
 	flags.IntVar(&conf.Indent, "indent", 4, "Indentation spaces (even number)")
+	flags.Var(&conf.NoAdditionalProperties, "noAdditionalProperties", "Default additionalProperties to false for all objects in the schema")
 
 	// Nested SchemaRoot flags
 	flags.StringVar(&conf.SchemaRoot.ID, "schemaRoot.id", "", "JSON schema ID")
@@ -87,6 +88,10 @@ func MergeConfig(fileConfig, flagConfig *Config) *Config {
 	}
 	if flagConfig.IndentSet || mergedConfig.Indent == 0 {
 		mergedConfig.Indent = flagConfig.Indent
+	}
+
+	if flagConfig.NoAdditionalProperties.IsSet() {
+		mergedConfig.NoAdditionalProperties = flagConfig.NoAdditionalProperties
 	}
 	if flagConfig.SchemaRoot.ID != "" {
 		mergedConfig.SchemaRoot.ID = flagConfig.SchemaRoot.ID

--- a/pkg/cmd_test.go
+++ b/pkg/cmd_test.go
@@ -270,10 +270,11 @@ func TestMergeConfig(t *testing.T) {
 		{
 			name: "FlagConfigOverridesFileConfig",
 			fileConfig: &Config{
-				Input:      multiStringFlag{"fileInput.yaml"},
-				OutputPath: "fileOutput.json",
-				Draft:      2020,
-				Indent:     4,
+				Input:                  multiStringFlag{"fileInput.yaml"},
+				OutputPath:             "fileOutput.json",
+				Draft:                  2020,
+				Indent:                 4,
+				NoAdditionalProperties: BoolFlag{set: true, value: true},
 				SchemaRoot: SchemaRoot{
 					ID:                   "fileID",
 					Title:                "fileTitle",
@@ -282,10 +283,11 @@ func TestMergeConfig(t *testing.T) {
 				},
 			},
 			flagConfig: &Config{
-				Input:      multiStringFlag{"flagInput.yaml"},
-				OutputPath: "flagOutput.json",
-				Draft:      2019,
-				Indent:     2,
+				Input:                  multiStringFlag{"flagInput.yaml"},
+				OutputPath:             "flagOutput.json",
+				Draft:                  2019,
+				Indent:                 2,
+				NoAdditionalProperties: BoolFlag{set: true, value: false},
 				SchemaRoot: SchemaRoot{
 					ID:                   "flagID",
 					Title:                "flagTitle",
@@ -297,10 +299,11 @@ func TestMergeConfig(t *testing.T) {
 				IndentSet:     true,
 			},
 			expectedConfig: &Config{
-				Input:      multiStringFlag{"flagInput.yaml"},
-				OutputPath: "flagOutput.json",
-				Draft:      2019,
-				Indent:     2,
+				Input:                  multiStringFlag{"flagInput.yaml"},
+				OutputPath:             "flagOutput.json",
+				Draft:                  2019,
+				Indent:                 2,
+				NoAdditionalProperties: BoolFlag{set: true, value: false},
 				SchemaRoot: SchemaRoot{
 					ID:                   "flagID",
 					Title:                "flagTitle",

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -89,7 +89,7 @@ func GenerateJsonSchema(config *Config) error {
 	}
 
 	// Convert merged Schema into a JSON Schema compliant map
-	jsonSchemaMap, err := convertSchemaToMap(mergedSchema)
+	jsonSchemaMap, err := convertSchemaToMap(mergedSchema, config.NoAdditionalProperties.value)
 	if err != nil {
 		return err
 	}
@@ -97,6 +97,8 @@ func GenerateJsonSchema(config *Config) error {
 
 	if config.SchemaRoot.AdditionalProperties.IsSet() {
 		jsonSchemaMap["additionalProperties"] = config.SchemaRoot.AdditionalProperties.Value()
+	} else if config.NoAdditionalProperties.value {
+		jsonSchemaMap["additionalProperties"] = false
 	}
 
 	// If validation is successful, marshal the schema and save to the file

--- a/pkg/parser_test.go
+++ b/pkg/parser_test.go
@@ -271,7 +271,7 @@ func TestConvertSchemaToMap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := convertSchemaToMap(tt.schema)
+			got, err := convertSchemaToMap(tt.schema, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("convertSchemaToMap() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -299,6 +299,11 @@ func TestConvertSchemaToMapFail(t *testing.T) {
 		Properties: map[string]*Schema{"circular": recursiveSchema},
 	}
 
+	schemaWithPatternPropertiesError := &Schema{
+		Type:              "object",
+		PatternProperties: map[string]*Schema{"circular": recursiveSchema},
+	}
+
 	tests := []struct {
 		name        string
 		schema      *Schema
@@ -314,11 +319,16 @@ func TestConvertSchemaToMapFail(t *testing.T) {
 			schema:      schemaWithPropertiesError,
 			expectedErr: assert.Error,
 		},
+		{
+			name:        "Error with recursive patternProperties",
+			schema:      schemaWithPatternPropertiesError,
+			expectedErr: assert.Error,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := convertSchemaToMap(tc.schema)
+			_, err := convertSchemaToMap(tc.schema, false)
 			tc.expectedErr(t, err)
 		})
 	}

--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -23,7 +23,7 @@ type Schema struct {
 	UniqueItems          bool               `json:"uniqueItems,omitempty"`
 	MaxProperties        *uint64            `json:"maxProperties,omitempty"`
 	MinProperties        *uint64            `json:"minProperties,omitempty"`
-	PatternProperties    interface{}        `json:"patternProperties,omitempty"`
+	PatternProperties    map[string]*Schema `json:"patternProperties,omitempty"`
 	Required             []string           `json:"required,omitempty"`
 	Items                *Schema            `json:"items,omitempty"`
 	ItemsEnum            []any              `json:"itemsEnum,omitempty"`
@@ -170,7 +170,7 @@ func processComment(schema *Schema, comment string) (isRequired bool, isHidden b
 					schema.MinProperties = &v
 				}
 			case "patternProperties":
-				var jsonObject interface{}
+				var jsonObject map[string]*Schema
 				if err := json.Unmarshal([]byte(value), &jsonObject); err == nil {
 					schema.PatternProperties = jsonObject
 				}

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -17,10 +17,11 @@ type SchemaRoot struct {
 
 // Save values of parsed flags in Config
 type Config struct {
-	Input      multiStringFlag `yaml:"input"`
-	OutputPath string          `yaml:"output"`
-	Draft      int             `yaml:"draft"`
-	Indent     int             `yaml:"indent"`
+	Input                  multiStringFlag `yaml:"input"`
+	OutputPath             string          `yaml:"output"`
+	Draft                  int             `yaml:"draft"`
+	Indent                 int             `yaml:"indent"`
+	NoAdditionalProperties BoolFlag        `yaml:"noAdditionalProperties"`
 
 	SchemaRoot SchemaRoot `yaml:"schemaRoot"`
 

--- a/testdata/noAdditionalProperties.schema.json
+++ b/testdata/noAdditionalProperties.schema.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+        "object": {
+            "additionalProperties": false,
+            "properties": {},
+            "type": "object"
+        },
+        "objectOfObjects": {
+            "additionalProperties": false,
+            "patternProperties": {
+                "^.*$": {
+                    "additionalProperties": false,
+                    "type": "object"
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "objectOfObjectsWithInnerAdditionalPropertiesAllowed": {
+            "additionalProperties": false,
+            "patternProperties": {
+                "^.*$": {
+                    "additionalProperties": true,
+                    "type": "object"
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "objectWithAdditionalPropertiesAllowed": {
+            "additionalProperties": true,
+            "properties": {},
+            "type": "object"
+        }
+    },
+    "type": "object"
+}

--- a/testdata/noAdditionalProperties.yaml
+++ b/testdata/noAdditionalProperties.yaml
@@ -1,0 +1,4 @@
+object: {}
+objectWithAdditionalPropertiesAllowed: {} # @schema additionalProperties: true
+objectOfObjects: {} # @schema patternProperties: { "^.*$": {"type": "object" } }
+objectOfObjectsWithInnerAdditionalPropertiesAllowed: {} # @schema patternProperties: { "^.*$": {"type": "object", "additionalProperties": true }}


### PR DESCRIPTION
This will default `additionalProperties` to `false` for all objects in the schema if set to `true`. The `additionalProperties` annotation, `schemaRoot.additionalProperties` and additionalProperties set via other ways (nested in `itemProperties`, `patternProperties` or similar) will take precedence over this setting, so it's fully backwards compatible.

Closes #95.