### PR TITLE
feature: add subschema keywords

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,11 @@ The following annotations are supported:
     * [title and description](#title-and-description)
     * [default](#default)
     * [readOnly](#readonly)
+* [Schema Composition](#schema-composition)
+    * [allOf](#allof)
+    * [anyOf](#anyof)
+    * [oneOf](#oneof)
+    * [not](#not)
 
 ## Validation Keywords for Any Instance Type
 
@@ -590,6 +595,123 @@ image:
         "tag": {
             "readOnly": true,
             "type": "string"
+        }
+    },
+    "type": "object"
+}
+```
+
+## Schema Composition
+
+Keywords for Applying Subschemas With Logic. Field `"type"` is dropped and you MUST declare it as part of the schema provided for the keyword.
+
+### allOf
+
+Non-empty array. Each item of the array MUST be a valid JSON Schema. [section 10.2.1.1](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.2.1.1)
+
+```yaml
+image:
+  digest: sha256:1234567890 # @schema allOf: [{"type": "string"}, {"minLength": 14}]
+```
+
+```json
+"image": {
+    "properties": {
+        "digest": {
+            "allOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "minLength": 14
+                }
+            ]
+        }
+    },
+    "type": "object"
+}
+```
+
+### anyOf
+
+Non-empty array. Each item of the array MUST be a valid JSON Schema. [section 10.2.1.2](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.2.1.2)
+
+```yaml
+cluster:
+  enabled: true
+  nodes: 3 # @schema anyOf: [{"type": "number", "multipleOf": 3}, {"type": "number", "multipleOf": 5}]
+```
+
+```json
+"cluster": {
+    "properties": {
+        "enabled": {
+            "type": "boolean"
+        },
+        "nodes": {
+            "anyOf": [
+                {
+                    "multipleOf": 3,
+                    "type": "number"
+                },
+                {
+                    "multipleOf": 5,
+                    "type": "number"
+                }
+            ]
+        }
+    },
+    "type": "object"
+}
+```
+
+### oneOf
+
+Non-empty array. Each item of the array MUST be a valid JSON Schema. [section 10.2.1.3](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.2.1.3)
+
+```yaml
+MY_SECRET:
+  ref: "secret-reference-in-manager"
+  version: # @schema oneOf: [{"type": "string"}, {"type": "number"}]
+```
+
+```json
+"MY_SECRET": {
+    "properties": {
+        "ref": {
+            "type": "string"
+        },
+        "version": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        }
+    },
+    "type": "object"
+}
+```
+
+### not
+
+A valid JSON Schema. [section 10.2.1.4](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.2.1.4)
+
+```yaml
+image:
+  tag: latest # @schema not: {"type": "object"}
+```
+
+```json
+"image": {
+    "properties": {
+        "tag": {
+            "not": {
+                "type": "object"
+            }
         }
     },
     "type": "object"

--- a/pkg/parser.go
+++ b/pkg/parser.go
@@ -74,6 +74,18 @@ func mergeSchemas(dest, src *Schema) *Schema {
 	if src.Ref != "" {
 		dest.Ref = src.Ref
 	}
+	if src.AllOf != nil {
+		dest.AllOf = src.AllOf
+	}
+	if src.AnyOf != nil {
+		dest.AnyOf = src.AnyOf
+	}
+	if src.OneOf != nil {
+		dest.OneOf = src.OneOf
+	}
+	if src.Not != nil {
+		dest.Not = src.Not
+	}
 
 	// Merge 'enum' field (assuming that maintaining order doesn't matter)
 	dest.Enum = append(dest.Enum, src.Enum...)
@@ -183,6 +195,22 @@ func convertSchemaToMapRec(schema *Schema, visited map[uintptr]bool, noAdditiona
 	}
 	if schema.Ref != "" {
 		schemaMap["$ref"] = schema.Ref
+	}
+	if schema.AllOf != nil {
+		delete(schemaMap, "type")
+		schemaMap["allOf"] = schema.AllOf
+	}
+	if schema.AnyOf != nil {
+		delete(schemaMap, "type")
+		schemaMap["anyOf"] = schema.AnyOf
+	}
+	if schema.OneOf != nil {
+		delete(schemaMap, "type")
+		schemaMap["oneOf"] = schema.OneOf
+	}
+	if schema.Not != nil {
+		delete(schemaMap, "type")
+		schemaMap["not"] = schema.Not
 	}
 
 	// Arrays

--- a/pkg/parser_test.go
+++ b/pkg/parser_test.go
@@ -231,7 +231,6 @@ func TestConvertSchemaToMap(t *testing.T) {
 				Not:      []any{map[string]any{"type": "string"}},
 			},
 			want: map[string]interface{}{
-				"type":          "object",
 				"minProperties": uint64(1),
 				"maxProperties": uint64(5),
 				"properties": map[string]interface{}{
@@ -258,7 +257,6 @@ func TestConvertSchemaToMap(t *testing.T) {
 				AllOf:       []any{map[string]any{"type": "string"}},
 			},
 			want: map[string]interface{}{
-				"type": "array",
 				"items": map[string]interface{}{
 					"type":                 "string",
 					"minLength":            uint64(1),
@@ -287,7 +285,6 @@ func TestConvertSchemaToMap(t *testing.T) {
 				OneOf:       []any{map[string]any{"type": "string"}},
 			},
 			want: map[string]interface{}{
-				"type":        "integer",
 				"multipleOf":  3.0,
 				"maximum":     10.0,
 				"minimum":     1.0,

--- a/pkg/parser_test.go
+++ b/pkg/parser_test.go
@@ -165,6 +165,30 @@ func TestMergeSchemas(t *testing.T) {
 			src:  &Schema{Type: "object", Title: "My Title", Description: "My description", ReadOnly: true, Default: "default value", ID: "http://example.com/schema", Ref: "schema/product.json"},
 			want: &Schema{Type: "object", Title: "My Title", Description: "My description", ReadOnly: true, Default: "default value", ID: "http://example.com/schema", Ref: "schema/product.json"},
 		},
+		{
+			name: "allOf",
+			dest: &Schema{Type: "object"},
+			src:  &Schema{Type: "object", AllOf: []any{map[string]any{"type": "string"}}},
+			want: &Schema{Type: "object", AllOf: []any{map[string]any{"type": "string"}}},
+		},
+		{
+			name: "anyOf",
+			dest: &Schema{Type: "object"},
+			src:  &Schema{Type: "object", AnyOf: []any{map[string]any{"type": "string"}}},
+			want: &Schema{Type: "object", AnyOf: []any{map[string]any{"type": "string"}}},
+		},
+		{
+			name: "oneOf",
+			dest: &Schema{Type: "object"},
+			src:  &Schema{Type: "object", OneOf: []any{map[string]any{"type": "string"}}},
+			want: &Schema{Type: "object", OneOf: []any{map[string]any{"type": "string"}}},
+		},
+		{
+			name: "not",
+			dest: &Schema{Type: "object"},
+			src:  &Schema{Type: "object", Not: []any{map[string]any{"type": "string"}}},
+			want: &Schema{Type: "object", Not: []any{map[string]any{"type": "string"}}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -203,6 +227,8 @@ func TestConvertSchemaToMap(t *testing.T) {
 				Required: []string{"foo"},
 				ID:       "http://example.com/schema",
 				Ref:      "schema/product.json",
+				AnyOf:    []any{map[string]any{"type": "string"}},
+				Not:      []any{map[string]any{"type": "string"}},
 			},
 			want: map[string]interface{}{
 				"type":          "object",
@@ -216,6 +242,8 @@ func TestConvertSchemaToMap(t *testing.T) {
 				"required": []string{"foo"},
 				"$id":      "http://example.com/schema",
 				"$ref":     "schema/product.json",
+				"anyOf":    []any{map[string]any{"type": "string"}},
+				"not":      []any{map[string]any{"type": "string"}},
 			},
 		},
 		{
@@ -227,6 +255,7 @@ func TestConvertSchemaToMap(t *testing.T) {
 				MaxItems:    uint64Ptr(2),
 				UniqueItems: true,
 				ReadOnly:    true,
+				AllOf:       []any{map[string]any{"type": "string"}},
 			},
 			want: map[string]interface{}{
 				"type": "array",
@@ -240,6 +269,7 @@ func TestConvertSchemaToMap(t *testing.T) {
 				"maxItems":    uint64(2),
 				"uniqueItems": true,
 				"readOnly":    true,
+				"allOf":       []any{map[string]any{"type": "string"}},
 			},
 		},
 		{
@@ -254,6 +284,7 @@ func TestConvertSchemaToMap(t *testing.T) {
 				Description: "some description",
 				Enum:        []interface{}{1, 2, 3},
 				Default:     "default",
+				OneOf:       []any{map[string]any{"type": "string"}},
 			},
 			want: map[string]interface{}{
 				"type":        "integer",
@@ -265,6 +296,7 @@ func TestConvertSchemaToMap(t *testing.T) {
 				"description": "some description",
 				"enum":        []interface{}{1, 2, 3},
 				"default":     "default",
+				"oneOf":       []any{map[string]any{"type": "string"}},
 			},
 		},
 	}

--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -38,6 +38,10 @@ type Schema struct {
 	Hidden               bool               `json:"-"`
 	ID                   string             `json:"$id,omitempty"`
 	Ref                  string             `json:"$ref,omitempty"`
+	AllOf                interface{}        `json:"allOf,omitempty"`
+	AnyOf                interface{}        `json:"anyOf,omitempty"`
+	OneOf                interface{}        `json:"oneOf,omitempty"`
+	Not                  interface{}        `json:"not,omitempty"`
 }
 
 func getKind(value string) string {
@@ -220,6 +224,26 @@ func processComment(schema *Schema, comment string) (isRequired bool, isHidden b
 			case "hidden":
 				if v, err := strconv.ParseBool(value); err == nil && v {
 					isHidden = true
+				}
+			case "allOf":
+				var jsonObject interface{}
+				if err := json.Unmarshal([]byte(value), &jsonObject); err == nil {
+					schema.AllOf = jsonObject
+				}
+			case "anyOf":
+				var jsonObject interface{}
+				if err := json.Unmarshal([]byte(value), &jsonObject); err == nil {
+					schema.AnyOf = jsonObject
+				}
+			case "oneOf":
+				var jsonObject interface{}
+				if err := json.Unmarshal([]byte(value), &jsonObject); err == nil {
+					schema.OneOf = jsonObject
+				}
+			case "not":
+				var jsonObject interface{}
+				if err := json.Unmarshal([]byte(value), &jsonObject); err == nil {
+					schema.Not = jsonObject
 				}
 			}
 		}

--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -343,6 +343,34 @@ func TestProcessComment(t *testing.T) {
 			expectedSchema:   &Schema{},
 			expectedRequired: false,
 		},
+		{
+			name:             "Set allOf",
+			schema:           &Schema{},
+			comment:          "# @schema allOf:[{\"type\":\"string\"}]",
+			expectedSchema:   &Schema{AllOf: []any{map[string]any{"type": "string"}}},
+			expectedRequired: false,
+		},
+		{
+			name:             "Set anyOf",
+			schema:           &Schema{},
+			comment:          "# @schema anyOf:[{\"type\":\"string\"}]",
+			expectedSchema:   &Schema{AnyOf: []any{map[string]any{"type": "string"}}},
+			expectedRequired: false,
+		},
+		{
+			name:             "Set oneOf",
+			schema:           &Schema{},
+			comment:          "# @schema oneOf:[{\"type\":\"string\"}]",
+			expectedSchema:   &Schema{OneOf: []any{map[string]any{"type": "string"}}},
+			expectedRequired: false,
+		},
+		{
+			name:             "Set not",
+			schema:           &Schema{},
+			comment:          "# @schema not:[{\"type\":\"string\"}]",
+			expectedSchema:   &Schema{Not: []any{map[string]any{"type": "string"}}},
+			expectedRequired: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/testdata/subschema.schema.json
+++ b/testdata/subschema.schema.json
@@ -1,0 +1,70 @@
+{
+    "$id": "https://example.com/schema",
+    "$ref": "schema/product.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
+    "description": "Schema for Helm values",
+    "properties": {
+        "MY_SECRET": {
+            "properties": {
+                "ref": {
+                    "type": "string"
+                },
+                "version": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "cluster": {
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "nodes": {
+                    "anyOf": [
+                        {
+                            "multipleOf": 3,
+                            "type": "number"
+                        },
+                        {
+                            "multipleOf": 5,
+                            "type": "number"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "image": {
+            "properties": {
+                "digest": {
+                    "allOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "minLength": 14
+                        }
+                    ]
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "title": "Helm Values Schema",
+    "type": "object"
+}

--- a/testdata/subschema.schema.json
+++ b/testdata/subschema.schema.json
@@ -59,7 +59,9 @@
                     "type": "string"
                 },
                 "tag": {
-                    "type": "string"
+                    "not": {
+                        "type": "object"
+                    }
                 }
             },
             "type": "object"

--- a/testdata/subschema.yaml
+++ b/testdata/subschema.yaml
@@ -5,10 +5,9 @@ MY_SECRET:
 
 image:
   repository: nginx
-  tag: latest
+  tag: latest # @schema not: {"type": "object"}
   digest: sha256:1234567890 # @schema allOf: [{"type": "string"}, {"minLength": 14}]
 
-# Factoring schemas
 cluster:
   enabled: true
   nodes: 3 # @schema anyOf: [{"type": "number", "multipleOf": 3}, {"type": "number", "multipleOf": 5}]

--- a/testdata/subschema.yaml
+++ b/testdata/subschema.yaml
@@ -1,0 +1,14 @@
+# Schema composition
+MY_SECRET:
+  ref: "secret-reference-in-manager"
+  version: # @schema oneOf: [{"type": "string"}, {"type": "number"}]
+
+image:
+  repository: nginx
+  tag: latest
+  digest: sha256:1234567890 # @schema allOf: [{"type": "string"}, {"minLength": 14}]
+
+# Factoring schemas
+cluster:
+  enabled: true
+  nodes: 3 # @schema anyOf: [{"type": "number", "multipleOf": 3}, {"type": "number", "multipleOf": 5}]


### PR DESCRIPTION
subschema keywords supported:
- `allOf`
- `anyOf`
- `oneOf`
- `not`

NOTE: when subschema keywords are used, the `"type"` filed is dropped from the generated schema. You MUST add it as part of the required array and valid schema for the keyword

closes #110