### PR TITLE
Fix command to install by removing output

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Helm plugin for generating `values.schema.json` from single or multiple values f
 ## Installation
 
 ```bash
-$ helm plugin install https://github.com/losisin/helm-values-schema-json.git
-Installed plugin: schema
+helm plugin install https://github.com/losisin/helm-values-schema-json.git
 ```
 
 ## Features


### PR DESCRIPTION
1. $ doesn't allow for seamless copy paste
2. Also copies the output which is not needed