### PR TITLE
Fix `-bundleWithoutID` when subschema has local inline references

### DIFF
--- a/pkg/bundle.go
+++ b/pkg/bundle.go
@@ -148,6 +148,14 @@ func iterMapOrdered[K cmp.Ordered, V any](m map[K]V) iter.Seq2[K, V] {
 }
 
 func generateBundledName(id string, defs map[string]*Schema) string {
+	if id == "" {
+		return ""
+	}
+	for name, def := range defs {
+		if def.ID == id {
+			return name
+		}
+	}
 	baseName := path.Base(id)
 	name := baseName
 	i := 1

--- a/pkg/bundle.go
+++ b/pkg/bundle.go
@@ -115,11 +115,6 @@ func moveDefToRoot(root *Schema, defs *map[string]*Schema) {
 
 func iterSubschemas(schema *Schema) iter.Seq2[Ptr, *Schema] {
 	return func(yield func(Ptr, *Schema) bool) {
-		if schema.Items != nil {
-			if !yield(NewPtr("items"), schema.Items) {
-				return
-			}
-		}
 		for key, subSchema := range iterMapOrdered(schema.Properties) {
 			if !yield(NewPtr("properties", key), subSchema) {
 				return
@@ -127,6 +122,11 @@ func iterSubschemas(schema *Schema) iter.Seq2[Ptr, *Schema] {
 		}
 		for key, subSchema := range iterMapOrdered(schema.PatternProperties) {
 			if !yield(NewPtr("patternProperties", key), subSchema) {
+				return
+			}
+		}
+		if schema.Items != nil {
+			if !yield(NewPtr("items"), schema.Items) {
 				return
 			}
 		}

--- a/pkg/bundle.go
+++ b/pkg/bundle.go
@@ -225,7 +225,7 @@ func BundleRemoveIDs(schema *Schema) error {
 	if schema == nil {
 		return fmt.Errorf("nil schema")
 	}
-	if err := bundleChangeRefsRec("#", schema, schema); err != nil {
+	if err := bundleChangeRefsRec("", schema, schema); err != nil {
 		return err
 	}
 	for _, def := range schema.Defs {

--- a/pkg/bundle_test.go
+++ b/pkg/bundle_test.go
@@ -203,8 +203,15 @@ func TestBundle(t *testing.T) {
 					switch ref.String() {
 					case "foo.json":
 						return &Schema{
-							Properties: map[string]*Schema{"num": {Ref: "bar.json"}},
-							Defs:       map[string]*Schema{"bar.json": {Type: "number"}},
+							Properties: map[string]*Schema{
+								"num": {Ref: "bar.json"},
+							},
+							Defs: map[string]*Schema{
+								"bar.json": {
+									ID:   "bar.json",
+									Type: "number",
+								},
+							},
 						}, nil
 					default:
 						return nil, fmt.Errorf("undefined test schema: %s", ref)
@@ -214,8 +221,16 @@ func TestBundle(t *testing.T) {
 			want: &Schema{
 				Items: &Schema{Ref: "foo.json"},
 				Defs: map[string]*Schema{
-					"foo.json": {Properties: map[string]*Schema{"num": {Ref: "bar.json"}}},
-					"bar.json": {Type: "number"},
+					"foo.json": {
+						ID: "foo.json",
+						Properties: map[string]*Schema{
+							"num": {Ref: "bar.json"},
+						},
+					},
+					"bar.json": {
+						ID:   "bar.json",
+						Type: "number",
+					},
 				},
 			},
 		},

--- a/pkg/bundle_test.go
+++ b/pkg/bundle_test.go
@@ -380,6 +380,14 @@ func TestBundleRemoveIDs(t *testing.T) {
 			err := BundleRemoveIDs(tt.schema)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, tt.schema)
+
+			want, err := yaml.Marshal(tt.want)
+			require.NoError(t, err)
+			t.Logf("Want:\n%s", string(want))
+
+			got, err := yaml.Marshal(tt.schema)
+			require.NoError(t, err)
+			t.Logf("Got:\n%s", string(got))
 		})
 	}
 }

--- a/pkg/bundle_test.go
+++ b/pkg/bundle_test.go
@@ -16,6 +16,50 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestBundleRefToID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{
+			name: "empty id",
+			ref:  "",
+			want: "",
+		},
+		{
+			name: "valid",
+			ref:  "https://localhost/foo/bar",
+			want: "https://localhost/foo/bar",
+		},
+		{
+			name: "keeps userinfo",
+			ref:  "https://user:pass@localhost/foo/bar",
+			want: "https://user:pass@localhost/foo/bar",
+		},
+		{
+			name: "removes fragment",
+			ref:  "https://localhost/foo/bar#mayo",
+			want: "https://localhost/foo/bar",
+		},
+		{
+			name: "invalid URL",
+			ref:  "::",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bundleRefToID(tt.ref)
+			if got != tt.want {
+				t.Fatalf("wrong result\nwant: %q\ngot:  %q", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestGenerateBundledName(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -522,8 +566,8 @@ func TestIterSubschemas_order(t *testing.T) {
 		{
 			name: "items",
 			schema: &Schema{
-				Items: &Schema{ID: "a"},
-				OneOf: []*Schema{{ID: "b"}, {ID: "c"}},
+				Properties: map[string]*Schema{"a": {ID: "a"}, "b": {ID: "b"}},
+				Items:      &Schema{ID: "c"},
 			},
 		},
 		{

--- a/pkg/bundle_test.go
+++ b/pkg/bundle_test.go
@@ -194,7 +194,7 @@ func TestBundle(t *testing.T) {
 		},
 
 		{
-			name: "subschema is bundled",
+			name: "subschema is bundled using id",
 			schema: &Schema{
 				Items: &Schema{Ref: "foo.json"},
 			},
@@ -230,6 +230,48 @@ func TestBundle(t *testing.T) {
 					"bar.json": {
 						ID:   "bar.json",
 						Type: "number",
+					},
+				},
+			},
+		},
+
+		{
+			name: "subschema is bundled without id",
+			schema: &Schema{
+				Items: &Schema{Ref: "foo.json"},
+			},
+			loader: DummyLoader{
+				func(ctx context.Context, ref *url.URL) (*Schema, error) {
+					switch ref.String() {
+					case "foo.json":
+						return &Schema{
+							Properties: map[string]*Schema{
+								"num": {Ref: "#/$defs/bar.json"},
+							},
+							Defs: map[string]*Schema{
+								"bar.json": {
+									Type: "number",
+								},
+							},
+						}, nil
+					default:
+						return nil, fmt.Errorf("undefined test schema: %s", ref)
+					}
+				},
+			},
+			want: &Schema{
+				Items: &Schema{Ref: "foo.json"},
+				Defs: map[string]*Schema{
+					"foo.json": {
+						ID: "foo.json",
+						Properties: map[string]*Schema{
+							"num": {Ref: "#/$defs/bar.json"},
+						},
+						Defs: map[string]*Schema{
+							"bar.json": {
+								Type: "number",
+							},
+						},
 					},
 				},
 			},

--- a/pkg/bundle_test.go
+++ b/pkg/bundle_test.go
@@ -284,7 +284,7 @@ func TestBundle_Errors(t *testing.T) {
 				},
 			},
 			loader:  DummyLoader{},
-			wantErr: `properties["foo"]: parse $ref as URL: parse "::": missing protocol scheme`,
+			wantErr: `/properties/foo: parse $ref as URL: parse "::": missing protocol scheme`,
 		},
 	}
 
@@ -405,7 +405,7 @@ func TestBundleRemoveIDs_Errors(t *testing.T) {
 					},
 				},
 			},
-			wantErr: `properties["foo"]: parse $ref="::" as URL: parse "::": missing protocol scheme`,
+			wantErr: `/properties/foo: parse $ref="::" as URL: parse "::": missing protocol scheme`,
 		},
 		{
 			name: "invalid ref",
@@ -416,7 +416,7 @@ func TestBundleRemoveIDs_Errors(t *testing.T) {
 					},
 				},
 			},
-			wantErr: `properties["foo"]: no $defs found that matches $ref="./no/$defs/with/this/ref"`,
+			wantErr: `/properties/foo: no $defs found that matches $ref="./no/$defs/with/this/ref"`,
 		},
 	}
 

--- a/pkg/pointer.go
+++ b/pkg/pointer.go
@@ -1,0 +1,65 @@
+package pkg
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// Ptr is a JSON Ptr [https://datatracker.ietf.org/doc/html/rfc6901].
+//
+// The type is meant to be used in an immutable way, where all methods
+// return a new pointer with the appropriate changes.
+//
+// You don't have to initialize this struct with the [NewPtr] function.
+// A nil value is equivalent to an empty path: "/"
+type Ptr []string
+
+// NewPtr returns a new [Ptr] with optionally provided property names
+func NewPtr(name ...string) Ptr {
+	return (Ptr{}).Prop(name...)
+}
+
+// pointerReplacer contains the replcements defined in https://datatracker.ietf.org/doc/html/rfc6901#section-3
+var pointerReplacer = strings.NewReplacer(
+	"~", "~0",
+	"/", "~1",
+)
+
+func (p Ptr) Prop(name ...string) Ptr {
+	for _, s := range name {
+		p = append(p, pointerReplacer.Replace(s))
+	}
+	return p
+}
+
+func (p Ptr) Item(index ...int) Ptr {
+	for _, i := range index {
+		p = append(p, strconv.Itoa(i))
+	}
+	return p
+}
+
+func (p Ptr) Add(other ...Ptr) Ptr {
+	for _, o := range other {
+		p = append(p, o...)
+	}
+	return p
+}
+
+func (p Ptr) HasPrefix(prefix Ptr) bool {
+	if len(prefix) > len(p) {
+		return false
+	}
+	return slices.Equal(p[:len(prefix)], prefix)
+}
+
+// String returns a slash-delimited string of the pointer.
+//
+// Example:
+//
+//	NewPtr("foo", "bar").String()
+//	// => "/foo/bar"
+func (p Ptr) String() string {
+	return "/" + strings.Join(p, "/")
+}

--- a/pkg/pointer_test.go
+++ b/pkg/pointer_test.go
@@ -1,0 +1,154 @@
+package pkg
+
+import "testing"
+
+func TestPtr(t *testing.T) {
+	tests := []struct {
+		name string
+		ptr  Ptr
+		want string
+	}{
+		{
+			name: "empty",
+			ptr:  Ptr{},
+			want: "/",
+		},
+
+		{
+			name: "single prop",
+			ptr:  Ptr{}.Prop("foo"),
+			want: "/foo",
+		},
+		{
+			name: "multiple props in different calls",
+			ptr:  Ptr{}.Prop("foo").Prop("bar"),
+			want: "/foo/bar",
+		},
+		{
+			name: "multiple props in the same call",
+			ptr:  Ptr{}.Prop("foo", "bar"),
+			want: "/foo/bar",
+		},
+
+		{
+			name: "single item",
+			ptr:  Ptr{}.Item(1),
+			want: "/1",
+		},
+		{
+			name: "multiple items in different calls",
+			ptr:  Ptr{}.Item(1).Item(2),
+			want: "/1/2",
+		},
+		{
+			name: "multiple items in the same call",
+			ptr:  Ptr{}.Item(1, 2),
+			want: "/1/2",
+		},
+
+		{
+			name: "adding other pointers",
+			ptr:  Ptr{"foo", "bar"}.Add(Ptr{"moo", "doo"}),
+			want: "/foo/bar/moo/doo",
+		},
+
+		{
+			name: "escapes slash",
+			ptr:  Ptr{}.Prop("foo/bar"),
+			want: "/foo~1bar",
+		},
+		{
+			name: "escapes tilde",
+			ptr:  Ptr{}.Prop("foo~bar"),
+			want: "/foo~0bar",
+		},
+		{
+			name: "escapes both",
+			ptr:  Ptr{}.Prop("foo/bar~moo/doo"),
+			want: "/foo~1bar~0moo~1doo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.ptr.String()
+			if got != tt.want {
+				t.Fatalf("wrong result\nwant: %q\ngot:  %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestPtr_HasPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		ptr    Ptr
+		prefix Ptr
+		want   bool
+	}{
+		{
+			name:   "empty both",
+			ptr:    nil,
+			prefix: nil,
+			want:   true,
+		},
+		{
+			name:   "empty prefix",
+			ptr:    Ptr{"foo"},
+			prefix: nil,
+			want:   true,
+		},
+		{
+			name:   "empty ptr",
+			ptr:    nil,
+			prefix: NewPtr("foo"),
+			want:   false,
+		},
+		{
+			name:   "longer prefix than ptr",
+			ptr:    NewPtr("foo"),
+			prefix: NewPtr("foo", "bar"),
+			want:   false,
+		},
+		{
+			name:   "match",
+			ptr:    NewPtr("foo", "bar"),
+			prefix: NewPtr("foo"),
+			want:   true,
+		},
+		{
+			name:   "match plain",
+			ptr:    NewPtr("foo", "bar"),
+			prefix: NewPtr("foo"),
+			want:   true,
+		},
+		{
+			name:   "match with special chars",
+			ptr:    NewPtr("foo/bar"),
+			prefix: NewPtr("foo/bar"),
+			want:   true,
+		},
+		{
+			name:   "no match because of special chars in ptr",
+			ptr:    NewPtr("foo/bar"),
+			prefix: NewPtr("foo"),
+			want:   false,
+		},
+		{
+			name:   "no match because of special chars in prefix",
+			ptr:    NewPtr("foo", "bar"),
+			prefix: NewPtr("foo/bar"),
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.ptr.HasPrefix(tt.prefix)
+			if got != tt.want {
+				t.Fatalf("wrong result\nptr:    %q\nprefix: %q\nwant:   %t\ngot:    %t",
+					tt.ptr, tt.prefix, tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -33,8 +33,8 @@ type Schema struct {
 	Description           string             `json:"description,omitempty" yaml:"description,omitempty"`
 	ReadOnly              bool               `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
 	Default               interface{}        `json:"default,omitempty" yaml:"default,omitempty"`
-	AdditionalProperties  *bool              `json:"additionalProperties" yaml:"additionalProperties"`
-	UnevaluatedProperties *bool              `json:"unevaluatedProperties" yaml:"unevaluatedProperties"`
+	AdditionalProperties  *bool              `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
+	UnevaluatedProperties *bool              `json:"unevaluatedProperties,omitempty" yaml:"unevaluatedProperties,omitempty"`
 	SkipProperties        bool               `json:"skipProperties,omitempty" yaml:"skipProperties,omitempty"`
 	Hidden                bool               `json:"-" yaml:"-"`
 	ID                    string             `json:"$id,omitempty" yaml:"$id,omitempty"`
@@ -92,7 +92,7 @@ func getSchemaURL(draft int) (string, error) {
 	}
 }
 
-func getComment(keyNode *yaml.Node, valNode *yaml.Node) string {
+func getComment(keyNode, valNode *yaml.Node) string {
 	if valNode.LineComment != "" {
 		return valNode.LineComment
 	}
@@ -119,7 +119,7 @@ func processList(comment string, stringsOnly bool) []interface{} {
 	return list
 }
 
-func processComment(schema *Schema, comment string) (isRequired bool, isHidden bool) {
+func processComment(schema *Schema, comment string) (isRequired, isHidden bool) {
 	isRequired = false
 	isHidden = false
 
@@ -264,7 +264,7 @@ func processComment(schema *Schema, comment string) (isRequired bool, isHidden b
 	return isRequired, isHidden
 }
 
-func parseNode(keyNode *yaml.Node, valNode *yaml.Node) (*Schema, bool) {
+func parseNode(keyNode, valNode *yaml.Node) (*Schema, bool) {
 	schema := &Schema{}
 
 	switch valNode.Kind {


### PR DESCRIPTION
This actually tackles multiple bugs:

- when loaded subschema has `$defs` with `$id`, then move those to the root schema
- when loaded subschema has `$ref: #/...`, and using `-bundleWithoutID`, then change it to `$ref: #/$defs/loaded.json/...`
- I forgot to go through `/items` when iterating subschemas

In the process I also added `Ptr` type that is a [JSON pointer](https://datatracker.ietf.org/doc/html/rfc6901), which is the syntax used in `$ref: #/...` URL fragments. They have a special encoding of `/` and `~` that we need to escape. This also slightly changes the error message. Maybe we want to use this in `convertSchemaToMap` too to give better hint at what part is having an error?

Some changes were also applied because I use [gofumpt](https://github.com/mvdan/gofumpt), like the following change:

```diff
-func getComment(keyNode *yaml.Node, valNode *yaml.Node) string {
+func getComment(keyNode, valNode *yaml.Node) string {
```

Closes #140
