### PR TITLE
Add shell completions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ install: build ## Install the plugin
 	@mkdir -p $(HELM_PLUGIN_DIR)
 	@cp $(BINNAME) $(HELM_PLUGIN_DIR)
 	@cp plugin.yaml $(HELM_PLUGIN_DIR)
+	@cp plugin.complete $(HELM_PLUGIN_DIR)
 
 generate: ## Generate files
 	go generate ./testdata

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -16,9 +17,13 @@ func main() {
 	}
 
 	// Parse CLI flags
+	var completeErr pkg.ErrCompletionRequested
 	flagConfig, output, err := pkg.ParseFlags(os.Args[0], os.Args[1:])
 	if err == flag.ErrHelp {
 		fmt.Println(output)
+		return
+	} else if errors.As(err, &completeErr) {
+		completeErr.PrintCompletions()
 		return
 	} else if err != nil {
 		fmt.Println("Error parsing flags:", output)

--- a/pkg/cmd_test.go
+++ b/pkg/cmd_test.go
@@ -138,6 +138,13 @@ func TestParseFlagsUsage(t *testing.T) {
 	}
 }
 
+func TestParseFlagsComplete(t *testing.T) {
+	_, _, err := ParseFlags("schema", []string{"--complete=true"})
+
+	var completeErr ErrCompletionRequested
+	assert.ErrorAs(t, err, &completeErr)
+}
+
 func TestParseFlagsFail(t *testing.T) {
 	tests := []struct {
 		args   []string

--- a/plugin.complete
+++ b/plugin.complete
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+"$HELM_PLUGIN_DIR/schema" --complete=true -- "$@"


### PR DESCRIPTION
This adds shell completions with the help from Helm's "plugin dynamic completion" feature.

This means that if the user has shell completions for `helm`, then they'll also get shell completions for this plugin.

Demo:

// todo: img

The completion has a little logic in it to make sure:

- boolean flags use `--foo=true` completion (with `=true` already filled in) as Go's `flag` package doesn't allow boolean flags using `--foo true`
- don't show any suggestions when completing the next argument (`""`) and the previous arg was a flag (starts with `-`). This is so e.g `--bundleRoot <tab>` doesn't suggest another flag but instead requires the user type in a value before suggesting the next flag
- otherwise, just print all the flags

Closes #146
