### PR TITLE
Fix parser not requiring `@schema` prefix

### DIFF
--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -779,6 +779,25 @@ func TestSplitCommentByParts(t *testing.T) {
 	}
 }
 
+func TestSplitCommentByParts_break(t *testing.T) {
+	type Pair struct {
+		Key, Value string
+	}
+
+	const comment = "# @schema foo:bar; moo:doo; baz:boz"
+
+	var pairs []Pair
+	for key, value := range splitCommentByParts(comment) {
+		pairs = append(pairs, Pair{key, value})
+		if len(pairs) == 2 {
+			break
+		}
+	}
+
+	want := []Pair{{"foo", "bar"}, {"moo", "doo"}}
+	assert.Equal(t, want, pairs)
+}
+
 func TestParseNode(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -696,6 +696,89 @@ func TestProcessComment(t *testing.T) {
 	}
 }
 
+func TestSplitCommentByParts(t *testing.T) {
+	type Pair struct {
+		Key, Value string
+	}
+	tests := []struct {
+		name    string
+		comment string
+		want    []Pair
+	}{
+		{
+			name:    "empty",
+			comment: "",
+			want:    nil,
+		},
+		{
+			name:    "no keys",
+			comment: "# @schema ",
+			want:    nil,
+		},
+		{
+			// https://github.com/losisin/helm-values-schema-json/issues/152
+			name:    "ignore when missing @schema",
+			comment: "# ; type:string",
+			want:    nil,
+		},
+		{
+			name:    "without whitespace",
+			comment: "#@schema type:string",
+			want:    []Pair{{"type", "string"}},
+		},
+		{
+			name:    "with extra whitespace",
+			comment: "#  \t  @schema \t type :  string",
+			want:    []Pair{{"type", "string"}},
+		},
+		{
+			name:    "missing whitespace after after @schema",
+			comment: "# @schematype:string",
+			want:    nil,
+		},
+		{
+			name:    "tab after @schema",
+			comment: "# @schema\ttype:string",
+			want:    []Pair{{"type", "string"}},
+		},
+		{
+			name:    "only key",
+			comment: "# @schema type",
+			want:    []Pair{{"type", ""}},
+		},
+		{
+			name:    "only value",
+			comment: "# @schema : string",
+			want:    []Pair{{"", "string"}},
+		},
+		{
+			name:    "multiple pairs",
+			comment: "# @schema type:string; foo:bar",
+			want:    []Pair{{"type", "string"}, {"foo", "bar"}},
+		},
+		{
+			name:    "same pair multiple times",
+			comment: "# @schema type:string; type:integer",
+			want:    []Pair{{"type", "string"}, {"type", "integer"}},
+		},
+		{
+			name:    "array value",
+			comment: "# @schema type:[string, integer]",
+			want:    []Pair{{"type", "[string, integer]"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var pairs []Pair
+			for key, value := range splitCommentByParts(tt.comment) {
+				pairs = append(pairs, Pair{key, value})
+			}
+			assert.Equal(t, tt.want, pairs)
+		})
+	}
+}
+
 func TestParseNode(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
Fixes the case where this:

```yaml
hello: # ; enum: dooblip
```

was parsed as:

- `enum:dooblip`

And as another example, this:

```yaml
hello: # foo:bar; moo:doo; maz:daz
```

was parsed as:

- `moo:doo`
- `maz:daz`

With this PR it doesn't get parsed at all.

It also fixes so `#@schema` and `#\t@schema` are parsed correctly

Closes #152
