### PR TITLE
Add support for head & foot comments

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,18 +1,72 @@
 # Annotations from comments
 
-JSON schema is partially implemented in this tool. It uses line comments to add annotations for the schema because head comments are frequently used by humans and tools like helm-docs. Multiple annotations can be added to a single line separated by semicolon. For example:
+JSON schema is partially implemented in this tool.
+It supports both comments directly above, directly below, and on the same line
+to add annotations for the schema.
+The comment must start with `# @schema`, which is used to avoid interference
+with tools like [helm-docs](https://github.com/norwoodj/helm-docs).
+
+Multiple annotations can be added to a single line separated by semicolon.
+
+Example:
 
 ```yaml
-nameOverride: "myapp" # @schema maxLength:10;pattern:^[a-z]+$
+# On the same line
+fullnameOverride: "myapp" # @schema maxLength:10;pattern:^[a-z]+$
+
+# On the line above
+# @schema maxLength:10;pattern:^[a-z]+$
+nameOverride: "myapp"
+
+# On the line below (double-check that indentation matches)
+resources:
+  limits: {}
+  requests: {}
+# @schema additionalProperties:false
 ```
 
 This will generate following schema:
 
 ```json
+"fullnameOverride": {
+    "type": "string",
+    "pattern": "^[a-z]+$",
+    "maxLength": 10
+},
 "nameOverride": {
-    "maxLength": 10,
-    "type": "string"
+    "type": "string",
+    "pattern": "^[a-z]+$",
+    "maxLength": 10
+},
+"resources": {
+    "type": "object",
+    "properties": {
+        "limits": {
+            "type": "object"
+        },
+        "requests": {
+            "type": "object"
+        }
+    },
+    "additionalProperties": false
 }
+```
+
+Keep in mind that if you use [helm-docs](https://github.com/norwoodj/helm-docs)
+and comments above the field then you want to place the `# @schema` comments
+above the helm-docs description comment to avoid having the schema annotations
+included in the description:
+
+```yaml
+# ✅ good:
+# @schema maxLength:10
+# -- My awesome nameOverride description
+nameOverride: "myapp"
+
+# ❌ bad:
+# -- My awesome nameOverride description
+# @schema maxLength:10
+nameOverride: "myapp"
 ```
 
 The following annotations are supported:

--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -448,7 +448,7 @@ func TestGetComment(t *testing.T) {
 		name            string
 		keyNode         *yaml.Node
 		valNode         *yaml.Node
-		expectedComment string
+		expectedComment []string
 	}{
 		{
 			name: "value node with comment",
@@ -461,7 +461,7 @@ func TestGetComment(t *testing.T) {
 				Value:       "some value",
 				LineComment: "# Value comment",
 			},
-			expectedComment: "# Value comment",
+			expectedComment: []string{"# Value comment"},
 		},
 		{
 			name: "value node without comment, key node with comment",
@@ -474,7 +474,7 @@ func TestGetComment(t *testing.T) {
 				Value:       "some value",
 				LineComment: "",
 			},
-			expectedComment: "# Key comment",
+			expectedComment: []string{"# Key comment"},
 		},
 		{
 			name: "empty value node, key node with comment",
@@ -487,14 +487,87 @@ func TestGetComment(t *testing.T) {
 				Value:       "",
 				LineComment: "",
 			},
-			expectedComment: "# Key comment",
+			expectedComment: []string{"# Key comment"},
+		},
+		{
+			name: "head comment single line",
+			keyNode: &yaml.Node{
+				Kind:        yaml.ScalarNode,
+				HeadComment: "# Key comment",
+				LineComment: "",
+			},
+			valNode: &yaml.Node{
+				Kind:        yaml.ScalarNode,
+				Value:       "",
+				LineComment: "",
+			},
+			expectedComment: []string{"# Key comment"},
+		},
+		{
+			name: "head comment multi line",
+			keyNode: &yaml.Node{
+				Kind:        yaml.ScalarNode,
+				HeadComment: "# Key comment\n# Second line",
+				LineComment: "",
+			},
+			valNode: &yaml.Node{
+				Kind:        yaml.ScalarNode,
+				Value:       "",
+				LineComment: "",
+			},
+			expectedComment: []string{"# Key comment", "# Second line"},
+		},
+		{
+			name: "head comment only last comment group",
+			keyNode: &yaml.Node{
+				Kind: yaml.ScalarNode,
+				HeadComment: "# First comment group\n# second line\n\n" +
+					"# Second comment group\n# second line 2\n\n" +
+					"# Last comment group\n# second line 3",
+				LineComment: "",
+			},
+			valNode: &yaml.Node{
+				Kind:        yaml.ScalarNode,
+				Value:       "",
+				LineComment: "",
+			},
+			expectedComment: []string{"# Last comment group", "# second line 3"},
+		},
+		{
+			name: "foot comment multi line",
+			keyNode: &yaml.Node{
+				Kind:        yaml.ScalarNode,
+				FootComment: "# Key comment\n# Second line",
+				LineComment: "",
+			},
+			valNode: &yaml.Node{
+				Kind:        yaml.ScalarNode,
+				Value:       "",
+				LineComment: "",
+			},
+			expectedComment: []string{"# Key comment", "# Second line"},
+		},
+		{
+			name: "head, line, and foot comment",
+			keyNode: &yaml.Node{
+				Kind:        yaml.ScalarNode,
+				HeadComment: "# Head comment",
+				LineComment: "# Line comment",
+				FootComment: "# Foot comment",
+			},
+			valNode: &yaml.Node{
+				Kind:        yaml.ScalarNode,
+				Value:       "",
+				LineComment: "",
+			},
+			expectedComment: []string{"# Head comment", "# Line comment", "# Foot comment"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			comment := getComment(tt.keyNode, tt.valNode)
-			assert.Equal(t, tt.expectedComment, comment, "getComment returned an unexpected comment")
+			comments := getComments(tt.keyNode, tt.valNode)
+			assert.Equal(t, tt.expectedComment, comments, "getComments returned an unexpected comment")
 		})
 	}
 }
@@ -689,7 +762,7 @@ func TestProcessComment(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var required bool
-			processComment(tt.schema, tt.comment)
+			processComment(tt.schema, []string{tt.comment})
 			assert.Equal(t, tt.expectedSchema, tt.schema)
 			assert.Equal(t, tt.expectedRequired, required)
 		})
@@ -701,77 +774,106 @@ func TestSplitCommentByParts(t *testing.T) {
 		Key, Value string
 	}
 	tests := []struct {
-		name    string
-		comment string
-		want    []Pair
+		name     string
+		comments []string
+		want     []Pair
 	}{
 		{
-			name:    "empty",
-			comment: "",
-			want:    nil,
+			name:     "empty",
+			comments: nil,
+			want:     nil,
 		},
 		{
-			name:    "no keys",
-			comment: "# @schema ",
-			want:    nil,
+			name:     "no keys",
+			comments: []string{"# @schema "},
+			want:     nil,
 		},
 		{
 			// https://github.com/losisin/helm-values-schema-json/issues/152
-			name:    "ignore when missing @schema",
-			comment: "# ; type:string",
-			want:    nil,
+			name:     "ignore when missing @schema",
+			comments: []string{"# ; type:string"},
+			want:     nil,
 		},
 		{
-			name:    "without whitespace",
-			comment: "#@schema type:string",
-			want:    []Pair{{"type", "string"}},
+			name:     "without whitespace",
+			comments: []string{"#@schema type:string"},
+			want:     []Pair{{"type", "string"}},
 		},
 		{
-			name:    "with extra whitespace",
-			comment: "#  \t  @schema \t type :  string",
-			want:    []Pair{{"type", "string"}},
+			name:     "with extra whitespace",
+			comments: []string{"#  \t  @schema \t type :  string"},
+			want:     []Pair{{"type", "string"}},
 		},
 		{
-			name:    "missing whitespace after after @schema",
-			comment: "# @schematype:string",
-			want:    nil,
+			name:     "missing whitespace after after @schema",
+			comments: []string{"# @schematype:string"},
+			want:     nil,
 		},
 		{
-			name:    "tab after @schema",
-			comment: "# @schema\ttype:string",
-			want:    []Pair{{"type", "string"}},
+			name:     "tab after @schema",
+			comments: []string{"# @schema\ttype:string"},
+			want:     []Pair{{"type", "string"}},
 		},
 		{
-			name:    "only key",
-			comment: "# @schema type",
-			want:    []Pair{{"type", ""}},
+			name:     "only key",
+			comments: []string{"# @schema type"},
+			want:     []Pair{{"type", ""}},
 		},
 		{
-			name:    "only value",
-			comment: "# @schema : string",
-			want:    []Pair{{"", "string"}},
+			name:     "only value",
+			comments: []string{"# @schema : string"},
+			want:     []Pair{{"", "string"}},
 		},
 		{
-			name:    "multiple pairs",
-			comment: "# @schema type:string; foo:bar",
-			want:    []Pair{{"type", "string"}, {"foo", "bar"}},
+			name:     "multiple pairs",
+			comments: []string{"# @schema type:string; foo:bar"},
+			want:     []Pair{{"type", "string"}, {"foo", "bar"}},
 		},
 		{
-			name:    "same pair multiple times",
-			comment: "# @schema type:string; type:integer",
-			want:    []Pair{{"type", "string"}, {"type", "integer"}},
+			name:     "same pair multiple times",
+			comments: []string{"# @schema type:string; type:integer"},
+			want:     []Pair{{"type", "string"}, {"type", "integer"}},
 		},
 		{
-			name:    "array value",
-			comment: "# @schema type:[string, integer]",
-			want:    []Pair{{"type", "[string, integer]"}},
+			name:     "array value",
+			comments: []string{"# @schema type:[string, integer]"},
+			want:     []Pair{{"type", "[string, integer]"}},
+		},
+		{
+			name: "multiple comments",
+			comments: []string{
+				"# @schema type:string",
+				"# @schema foo:bar",
+				"# @schema moo:doo",
+			},
+			want: []Pair{
+				{"type", "string"},
+				{"foo", "bar"},
+				{"moo", "doo"},
+			},
+		},
+		{
+			name: "multiple pairs on multiple comments",
+			comments: []string{
+				"# @schema type:string; lorem:ipsum",
+				"# @schema foo:bar; foz:baz",
+				"# @schema moo:doo; moz:doz",
+			},
+			want: []Pair{
+				{"type", "string"},
+				{"lorem", "ipsum"},
+				{"foo", "bar"},
+				{"foz", "baz"},
+				{"moo", "doo"},
+				{"moz", "doz"},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var pairs []Pair
-			for key, value := range splitCommentByParts(tt.comment) {
+			for key, value := range splitCommentByParts(tt.comments) {
 				pairs = append(pairs, Pair{key, value})
 			}
 			assert.Equal(t, tt.want, pairs)
@@ -784,10 +886,10 @@ func TestSplitCommentByParts_break(t *testing.T) {
 		Key, Value string
 	}
 
-	const comment = "# @schema foo:bar; moo:doo; baz:boz"
+	comments := []string{"# @schema foo:bar; moo:doo; baz:boz"}
 
 	var pairs []Pair
-	for key, value := range splitCommentByParts(comment) {
+	for key, value := range splitCommentByParts(comments) {
 		pairs = append(pairs, Pair{key, value})
 		if len(pairs) == 2 {
 			break

--- a/testdata/full.yaml
+++ b/testdata/full.yaml
@@ -26,7 +26,9 @@ tolerations: # @schema minItems: 1 ; maxItems: 10 ; uniqueItems: true
     value: "baz"
     effect: "NoSchedule"
 
-labels:  # @schema skipProperties:true
+# Comments on line above
+# @schema skipProperties:true
+labels:
   hello: world
   foo: bar
 
@@ -35,27 +37,29 @@ affinity:
   nodeAffinity: # @schema minProperties: 1 ; maxProperties: 2 ; additionalProperties: false
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
-      - matchExpressions:
-        - key: topology.kubernetes.io/zone
-          operator: In
-          values:
-          - antarctica-east1
-          - antarctica-west1
+        - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+                - antarctica-east1
+                - antarctica-west1
     preferredDuringSchedulingIgnoredDuringExecution:
-    - weight: 1
-      preference: # @schema patternProperties: {"^[a-z]$": {"type": "string"}} ; $id: https://example.com/schema.json
-        matchExpressions:
-        - key: another-node-label-key
-          operator: In
-          values:
-          - another-node-label-value
+      - weight: 1
+        preference: # @schema patternProperties: {"^[a-z]$": {"type": "string"}} ; $id: https://example.com/schema.json
+          matchExpressions:
+            - key: another-node-label-key
+              operator: In
+              values:
+                - another-node-label-value
 
-subchart: # @schema $ref: https://example.com/schema.json ; unevaluatedProperties: false
+# Comments directly below
+subchart:
   enabled: true
   name: subchart
   values:
     foo: bar
     bar: baz
+# @schema $ref: https://example.com/schema.json ; unevaluatedProperties: false
 
 monitoring: # @schema hidden: true
-  enabled: true 
+  enabled: true


### PR DESCRIPTION
Now if I read you correctly, then this feature might be a little controversial.

Implementation wise, this is quite simple.

However I saw two counter-arguments:

## Collides with helm-docs

When I was testing helm-docs, it was possible to work around it so it doesn't collide. Helm-docs does not error when it sees `@schema` comments, so it's fully possible to have them co-exist.

You have to make sure you put the `@schema` comments above the helm-docs `# -- my description` comment, which is less nice. But at least it is possible.

## Makes it more difficult to read

The schema comments does pollute the comment space for when skimming comments and makes it harder to read.

However the foot comments help with that. So instead of this:

```yaml
# @schema enum:[IfNotPresent, Always, Never]
# -- This sets the pull policy for images.
pullPolicy: IfNotPresent
```

then you could do this:

```yaml
# -- This sets the pull policy for images.
pullPolicy: IfNotPresent
# @schema enum:[IfNotPresent, Always, Never]
```

which does move the schema annotations away from the "human readable part".

A future addition might consider adding support for placing comments at the bottom of the document like this:

```yaml
# -- This sets the pull policy for images.
pullPolicy: IfNotPresent



# @schema.pullPolicy enum:[IfNotPresent, Always, Never]
```

---

So features I would leave for future PRs:

1. Support placing `# @schema.foobar` comments at the end of the document
2. Support reusing helm-docs descriptions

Closes #52
