### PR TITLE
Use `allOf` on `$ref` when targeting draft 7 or below

### DIFF
--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -128,7 +128,7 @@ func GenerateJsonSchema(config *Config) error {
 	}
 
 	// Ensure merged Schema is JSON Schema compliant
-	if err := ensureCompliant(mergedSchema, config.NoAdditionalProperties.value); err != nil {
+	if err := ensureCompliant(mergedSchema, config.NoAdditionalProperties.value, config.Draft); err != nil {
 		return err
 	}
 	mergedSchema.Schema = schemaURL // Include the schema draft version

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -68,6 +68,31 @@ func TestGenerateJsonSchema(t *testing.T) {
 		},
 
 		{
+			name: "ref draft 7",
+			config: &Config{
+				Draft:  7,
+				Indent: 4,
+				Input: []string{
+					"../testdata/ref.yaml",
+				},
+				OutputPath: "../testdata/ref-draft7_output.json",
+			},
+			templateSchemaFile: "../testdata/ref-draft7.schema.json",
+		},
+		{
+			name: "ref draft 2020",
+			config: &Config{
+				Draft:  2020,
+				Indent: 4,
+				Input: []string{
+					"../testdata/ref.yaml",
+				},
+				OutputPath: "../testdata/ref-draft2020_output.json",
+			},
+			templateSchemaFile: "../testdata/ref-draft2020.schema.json",
+		},
+
+		{
 			name: "bundle/simple",
 			config: &Config{
 				Draft:      2020,

--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -119,6 +119,52 @@ type Schema struct {
 	Hidden         bool `json:"-" yaml:"-"`
 }
 
+func (s *Schema) IsZero() bool {
+	if s == nil {
+		return true
+	}
+	switch {
+	case s.kind != 0,
+		len(s.Schema) > 0,
+		len(s.ID) > 0,
+		len(s.Title) > 0,
+		len(s.Description) > 0,
+		len(s.Comment) > 0,
+		s.ReadOnly,
+		s.Default != nil,
+		len(s.Ref) > 0,
+		s.Type != nil,
+		len(s.Enum) > 0,
+		len(s.AllOf) > 0,
+		len(s.AnyOf) > 0,
+		len(s.OneOf) > 0,
+		s.Not != nil,
+		s.Maximum != nil,
+		s.Minimum != nil,
+		s.MultipleOf != nil,
+		len(s.Pattern) > 0,
+		s.MaxLength != nil,
+		s.MinLength != nil,
+		s.MaxItems != nil,
+		s.MinItems != nil,
+		s.UniqueItems,
+		s.Items != nil,
+		s.AdditionalItems != nil,
+		len(s.Required) > 0,
+		s.MaxProperties != nil,
+		s.MinProperties != nil,
+		len(s.Properties) > 0,
+		len(s.PatternProperties) > 0,
+		s.AdditionalProperties != nil,
+		s.UnevaluatedProperties != nil,
+		len(s.Defs) > 0,
+		len(s.Definitions) > 0:
+		return false
+	default:
+		return true
+	}
+}
+
 var (
 	_ json.Unmarshaler = &Schema{}
 	_ json.Marshaler   = &Schema{}

--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -52,6 +52,74 @@ func TestSchemaKindIsBool(t *testing.T) {
 	}
 }
 
+func TestSchemaIsZero(t *testing.T) {
+	var (
+		exampleUint64      = uint64(1)
+		exampleFloat64     = float64(1)
+		exampleString      = "foo"
+		exampleBool        = true
+		exampleSchema      = &Schema{ID: exampleString}
+		exampleMap         = map[string]*Schema{exampleString: exampleSchema}
+		exampleSchemaSlice = []*Schema{exampleSchema}
+		exampleAnySlice    = []any{exampleString}
+	)
+	tests := []struct {
+		name   string
+		schema *Schema
+		want   bool
+	}{
+		{name: "nil", schema: nil, want: true},
+		{name: "empty", schema: &Schema{}, want: true},
+		{name: "SkipProperties", schema: &Schema{SkipProperties: true}, want: true},
+		{name: "Hidden", schema: &Schema{Hidden: true}, want: true},
+
+		{name: "Kind", schema: &Schema{kind: SchemaKindTrue}},
+		{name: "Schema", schema: &Schema{Schema: exampleString}},
+		{name: "ID", schema: &Schema{ID: exampleString}},
+		{name: "Title", schema: &Schema{Title: exampleString}},
+		{name: "Description", schema: &Schema{Description: exampleString}},
+		{name: "Comment", schema: &Schema{Comment: exampleString}},
+		{name: "ReadOnly", schema: &Schema{ReadOnly: exampleBool}},
+		{name: "Default", schema: &Schema{Default: exampleString}},
+		{name: "Ref", schema: &Schema{Ref: exampleString}},
+		{name: "Type", schema: &Schema{Type: exampleString}},
+		{name: "Enum", schema: &Schema{Enum: exampleAnySlice}},
+		{name: "AllOf", schema: &Schema{AllOf: exampleSchemaSlice}},
+		{name: "AnyOf", schema: &Schema{AnyOf: exampleSchemaSlice}},
+		{name: "OneOf", schema: &Schema{OneOf: exampleSchemaSlice}},
+		{name: "Not", schema: &Schema{Not: &Schema{ID: exampleString}}},
+		{name: "Maximum", schema: &Schema{Maximum: &exampleFloat64}},
+		{name: "Minimum", schema: &Schema{Minimum: &exampleFloat64}},
+		{name: "MultipleOf", schema: &Schema{MultipleOf: &exampleFloat64}},
+		{name: "Pattern", schema: &Schema{Pattern: exampleString}},
+		{name: "MaxLength", schema: &Schema{MaxLength: &exampleUint64}},
+		{name: "MinLength", schema: &Schema{MinLength: &exampleUint64}},
+		{name: "MaxItems", schema: &Schema{MaxItems: &exampleUint64}},
+		{name: "MinItems", schema: &Schema{MinItems: &exampleUint64}},
+		{name: "UniqueItems", schema: &Schema{UniqueItems: exampleBool}},
+		{name: "Items", schema: &Schema{Items: &Schema{ID: exampleString}}},
+		{name: "AdditionalItems", schema: &Schema{AdditionalItems: &Schema{ID: exampleString}}},
+		{name: "Required", schema: &Schema{Required: []string{exampleString}}},
+		{name: "MaxProperties", schema: &Schema{MaxProperties: &exampleUint64}},
+		{name: "MinProperties", schema: &Schema{MinProperties: &exampleUint64}},
+		{name: "Properties", schema: &Schema{Properties: exampleMap}},
+		{name: "PatternProperties", schema: &Schema{PatternProperties: exampleMap}},
+		{name: "AdditionalProperties", schema: &Schema{AdditionalProperties: exampleSchema}},
+		{name: "UnevaluatedProperties", schema: &Schema{UnevaluatedProperties: &exampleBool}},
+		{name: "Defs", schema: &Schema{Defs: exampleMap}},
+		{name: "Definitions", schema: &Schema{Definitions: exampleMap}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.schema.IsZero()
+			if got != tt.want {
+				t.Errorf("wrong result\nwant: %t\ngot:  %t", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestSchemaJSONUnmarshal(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/testdata/doc.go
+++ b/testdata/doc.go
@@ -11,6 +11,8 @@ package testdata
 //go:generate go run .. --input k8sRef.yaml --output k8sRef.schema.json --k8sSchemaVersion v1.33.1
 //go:generate go run .. --input meta.yaml --output meta.schema.json
 //go:generate go run .. --input noAdditionalProperties.yaml --output noAdditionalProperties.schema.json --noAdditionalProperties=true
+//go:generate go run .. --input ref.yaml --output ref-draft2020.schema.json --draft 2020
+//go:generate go run .. --input ref.yaml --output ref-draft7.schema.json --draft 7
 //go:generate go run .. --input subschema.yaml --output subschema.schema.json
 
 //go:generate go run .. --bundle=true --input bundle/fragment.yaml --output bundle/fragment.schema.json

--- a/testdata/ref-draft2020.schema.json
+++ b/testdata/ref-draft2020.schema.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "resources": {
+            "$ref": "foo.json",
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object"
+                },
+                "requests": {
+                    "type": "object"
+                }
+            }
+        }
+    }
+}

--- a/testdata/ref-draft7.schema.json
+++ b/testdata/ref-draft7.schema.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "resources": {
+            "allOf": [
+                {
+                    "$ref": "foo.json"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object"
+                        },
+                        "requests": {
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/testdata/ref.yaml
+++ b/testdata/ref.yaml
@@ -1,0 +1,7 @@
+# In draft 7 using "$ref" would make other settings ignored.
+# But running helm-values-schema-json with "--draft 7" will cause it
+# to put "$ref" inside "allOf"
+
+resources: # @schema $ref: foo.json
+  limits: {}
+  requests: {}


### PR DESCRIPTION
Adds some logic to throw a subschema inside `allOf` when using `$ref` together with some other fields.

For example this YAML:

```yaml
resources: # @schema $ref: foo.json
  limits: {}
  requests: {}
```

Will by default continue to generate this when using draft 2019 or 2020:

```json
{
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "type": "object",
    "properties": {
        "resources": {
            "$ref": "foo.json",
            "type": "object",
            "properties": {
                "limits": {
                    "type": "object"
                },
                "requests": {
                    "type": "object"
                }
            }
        }
    }
}
```

But now gets turned into this when using `--draft 7`:

```json
{
    "$schema": "http://json-schema.org/draft-07/schema#",
    "type": "object",
    "properties": {
        "resources": {
            "allOf": [
                {
                    "$ref": "foo.json"
                },
                {
                    "type": "object",
                    "properties": {
                        "limits": {
                            "type": "object"
                        },
                        "requests": {
                            "type": "object"
                        }
                    }
                }
            ]
        }
    }
}
```

Because the `Schema` struct contains references to interfaces, then we can't just do `if schema == (Schema{})` but instead we have to implement our own `IsZero`, which kind of sucks.

Closes #138
