### PR TITLE
Prepare Go module path for v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/losisin/helm-values-schema-json
+module github.com/losisin/helm-values-schema-json/v2
 
 go 1.24.2
 

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/losisin/helm-values-schema-json/pkg"
+	"github.com/losisin/helm-values-schema-json/v2/pkg"
 )
 
 func main() {


### PR DESCRIPTION
This assumes the next version is going to be v2.0.0

Go has their odd versioning scheme thing, so if someone wants to do `go install` on this project and the Git tag is v2.x.x then it has to be under this "fake `/v2/` path"
