### PR TITLE
Fix bundling with $ref on schema root (for v1)

### DIFF
--- a/.schema.yaml
+++ b/.schema.yaml
@@ -15,7 +15,7 @@ k8sSchemaVersion: "v1.33.1"
 
 schemaRoot:
   id: https://example.com/schema
-  ref: bundle/simple-subschema.schema.json
+  ref: testdata/bundle/simple-subschema.schema.json
   title: Helm Values Schema
   description: Schema for Helm values
   additionalProperties: true

--- a/pkg/cmd.go
+++ b/pkg/cmd.go
@@ -33,7 +33,7 @@ func ParseFlags(progname string, args []string) (*Config, string, error) {
 
 	// Nested SchemaRoot flags
 	flags.StringVar(&conf.SchemaRoot.ID, "schemaRoot.id", "", "JSON schema ID")
-	flags.StringVar(&conf.SchemaRoot.Ref, "schemaRoot.ref", "", "JSON schema URI reference")
+	flags.StringVar(&conf.SchemaRoot.Ref, "schemaRoot.ref", "", "JSON schema URI reference. Relative to current working directory when using \"-bundle true\".")
 	flags.StringVar(&conf.SchemaRoot.Title, "schemaRoot.title", "", "JSON schema title")
 	flags.StringVar(&conf.SchemaRoot.Description, "schemaRoot.description", "", "JSON schema description")
 	flags.Var(&conf.SchemaRoot.AdditionalProperties, "schemaRoot.additionalProperties", "Allow additional properties")

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -103,6 +103,10 @@ func GenerateJsonSchema(config *Config) error {
 
 		if config.Bundle.Value() {
 			ctx := context.Background()
+
+			// https://github.com/losisin/helm-values-schema-json/issues/159
+			tempSchema.Ref = FixRootSchemaRef(tempSchema.Ref, filePath)
+
 			basePath, err := filepath.Rel(bundleRoot, filepath.Dir(filePath))
 			if err != nil {
 				return fmt.Errorf("get relative path from bundle root to file %q: %w", filePath, err)

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -220,6 +220,25 @@ func TestGenerateJsonSchema(t *testing.T) {
 			},
 			templateSchemaFile: "../testdata/bundle/yaml.schema.json",
 		},
+		{
+			// https://github.com/losisin/helm-values-schema-json/issues/159
+			name: "bundle/root-ref",
+			config: &Config{
+				Draft:      2020,
+				Indent:     4,
+				Bundle:     BoolFlag{set: true, value: true},
+				BundleRoot: "..",
+				SchemaRoot: SchemaRoot{
+					// Should be relative to CWD, which is this ./pkg dir
+					Ref: "../testdata/bundle/simple-subschema.schema.json",
+				},
+				Input: []string{
+					"../testdata/bundle/simple.yaml",
+				},
+				OutputPath: "../testdata/bundle/simple-root-ref_output.json",
+			},
+			templateSchemaFile: "../testdata/bundle/simple-root-ref.schema.json",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/pointer.go
+++ b/pkg/pointer.go
@@ -72,6 +72,13 @@ func (p Ptr) HasPrefix(prefix Ptr) bool {
 	return slices.Equal(p[:len(prefix)], prefix)
 }
 
+func (p Ptr) Equals(other Ptr) bool {
+	if len(other) != len(p) {
+		return false
+	}
+	return slices.Equal(p, other)
+}
+
 // String returns a slash-delimited string of the pointer.
 //
 // Example:

--- a/pkg/pointer_test.go
+++ b/pkg/pointer_test.go
@@ -208,3 +208,77 @@ func TestPtr_HasPrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestPtr_Equals(t *testing.T) {
+	tests := []struct {
+		name  string
+		ptr   Ptr
+		other Ptr
+		want  bool
+	}{
+		{
+			name:  "nil both",
+			ptr:   nil,
+			other: nil,
+			want:  true,
+		},
+		{
+			name:  "empty both",
+			ptr:   NewPtr(),
+			other: NewPtr(),
+			want:  true,
+		},
+		{
+			name:  "nil lhs",
+			ptr:   nil,
+			other: NewPtr(),
+			want:  true,
+		},
+		{
+			name:  "nil rhs",
+			ptr:   NewPtr(),
+			other: nil,
+			want:  true,
+		},
+		{
+			name:  "value and nil",
+			ptr:   Ptr{"foo"},
+			other: nil,
+			want:  false,
+		},
+		{
+			name:  "nil and value",
+			ptr:   nil,
+			other: Ptr{"foo"},
+			want:  false,
+		},
+		{
+			name:  "longer other than ptr",
+			ptr:   NewPtr("foo"),
+			other: NewPtr("foo", "bar"),
+			want:  false,
+		},
+		{
+			name:  "match with special chars",
+			ptr:   NewPtr("foo/bar"),
+			other: NewPtr("foo/bar"),
+			want:  true,
+		},
+		{
+			name:  "no match because of special chars in ptr",
+			ptr:   NewPtr("foo/bar"),
+			other: NewPtr("foo", "bar"),
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.ptr.Equals(tt.other)
+			if got != tt.want {
+				t.Fatalf("wrong result\nptr:   %q\nother: %q\nwant:  %t\ngot:   %t",
+					tt.ptr, tt.other, tt.want, got)
+			}
+		})
+	}
+}

--- a/testdata/bundle/simple-root-ref.schema.json
+++ b/testdata/bundle/simple-root-ref.schema.json
@@ -1,0 +1,56 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "./simple-subschema.schema.json",
+    "type": "object",
+    "properties": {
+        "image": {
+            "$ref": "./simple-subschema.schema.json",
+            "type": "object",
+            "properties": {
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "imageToo": {
+            "$ref": "#/properties/image",
+            "type": "object"
+        }
+    },
+    "$defs": {
+        "simple-subschema.schema.json": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "./simple-subschema.schema.json",
+            "$comment": "Sample schema referenced by other schemas. This file is meant to be manually created and not automatically generated",
+            "type": "object",
+            "properties": {
+                "pullPolicy": {
+                    "description": "This sets the pull policy for images.",
+                    "type": "string",
+                    "enum": [
+                        "IfNotPresent",
+                        "Always",
+                        "Never"
+                    ]
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "description": "Overrides the image tag whose default is the chart appVersion.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "additionalProperties": false
+        }
+    }
+}

--- a/testdata/doc.go
+++ b/testdata/doc.go
@@ -24,3 +24,4 @@ package testdata
 //go:generate go run .. --bundle=false --input bundle/simple.yaml --output bundle/simple-disabled.schema.json
 //go:generate go run .. --bundle=true --input bundle/simple.yaml --output bundle/simple-without-id.schema.json --bundleWithoutID=true
 //go:generate go run .. --bundle=true --input bundle/yaml.yaml --output bundle/yaml.schema.json
+//go:generate go run .. --bundle=true --input bundle/simple.yaml --output bundle/simple-root-ref.schema.json --schemaRoot.ref ./bundle/simple-subschema.schema.json


### PR DESCRIPTION
There was an issue when using bundling together with schema root refs from config or flags.

This attempts to fix it by doing some `filepath.Rel` operations, so that what you define as schema root ref via config or flags are relative to current working directory, but then that gets translated on each file to be relative to the file. This is because the FileLoader reads this relative to the file's directory.

Closes #159

