### PR TITLE
Fix /bin/bash -> /usr/bin/env bash in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 BINNAME := schema
 PLUGIN_SHORTNAME := json-schema


### PR DESCRIPTION
Allows me to run `make` on my NixOS computer, as NixOS doesn't have bash at `/bin/bash`, but it does have `/usr/bin/env`

