### PR TITLE
Format loaded bytes with B, KB, and MB

### DIFF
--- a/pkg/bundle.go
+++ b/pkg/bundle.go
@@ -437,7 +437,7 @@ func (loader FileLoader) Load(_ context.Context, ref *url.URL) (*Schema, error) 
 		return nil, fmt.Errorf("read $ref=%q file: %w", ref, err)
 	}
 
-	fmt.Printf("=> got %dKB\n", len(b)/1000)
+	fmt.Printf("=> got %s\n", formatSizeBytes(len(b)))
 
 	switch filepath.Ext(path) {
 	case ".yml", ".yaml":
@@ -593,7 +593,7 @@ func (loader HTTPLoader) Load(ctx context.Context, ref *url.URL) (*Schema, error
 	}
 
 	duration := time.Since(start)
-	fmt.Printf("=> got %dKB in %s\n", len(b)/1000, duration.Truncate(time.Millisecond))
+	fmt.Printf("=> got %s in %s\n", formatSizeBytes(len(b)), duration.Truncate(time.Millisecond))
 
 	if isYAML {
 		var schema Schema
@@ -616,4 +616,15 @@ var loaderContextReferrer = loaderContextKey(1)
 
 func ContextWithLoaderReferrer(parent context.Context, referrer string) context.Context {
 	return context.WithValue(parent, loaderContextReferrer, referrer)
+}
+
+func formatSizeBytes(size int) string {
+	switch {
+	case size < 2_000:
+		return fmt.Sprintf("%dB", size)
+	case size < 2_000_000:
+		return fmt.Sprintf("%dKB", size/1_000)
+	default:
+		return fmt.Sprintf("%dMB", size/1_000_000)
+	}
 }

--- a/pkg/bundle_test.go
+++ b/pkg/bundle_test.go
@@ -1293,6 +1293,34 @@ func TestHTTPLoader_Error(t *testing.T) {
 	})
 }
 
+func TestFormatSizeBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		size int
+		want string
+	}{
+		{size: 0, want: "0B"},
+		{size: 1000, want: "1000B"},
+		{size: 1999, want: "1999B"},
+		{size: 2000, want: "2KB"},
+		{size: 10_000, want: "10KB"},
+		{size: 1_000_000, want: "1000KB"},
+		{size: 1_999_999, want: "1999KB"},
+		{size: 2_000_000, want: "2MB"},
+		{size: 10_000_000, want: "10MB"},
+		{size: 3_000_000_000_000, want: "3000000MB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := formatSizeBytes(tt.size)
+			if got != tt.want {
+				t.Errorf("wrong result\nwant: %q\ngot:  %q", tt.want, got)
+			}
+		})
+	}
+}
+
 func mustParseURL(rawURL string) *url.URL {
 	u, err := url.Parse(rawURL)
 	if err != nil {


### PR DESCRIPTION
Shows different units depending on size.

This is mostly to prevent it from showing `0KB` when file is below 1 KB

The threshold to switch from B to KB at 2 KB is completely arbitrary. I just felt like showing something like `1200B` is better than `1KB`
