### PR TITLE
chore: Fix .schema.yaml in v1 branch

### DIFF
--- a/.schema.yaml
+++ b/.schema.yaml
@@ -7,7 +7,7 @@ indent: 4 # @schema default: 4
 output: values.schema.json # @schema default: values.schema.json
 
 bundle: true # @schema default: false
-bundleRoot: testdata # @schema default: ""
+bundleRoot: "" # @schema default: ""
 bundleWithoutID: true # @schema default: false
 
 k8sSchemaURL: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/{{ .K8sSchemaVersion }}/


### PR DESCRIPTION
Fixes the `.schema.yaml` file in the `v1` branch.

Now `go test .` works

I fixed this in #167 for the `main` branch, but in this PR I'm backporting it to the `v1` branch
