### PR TITLE
chore: Change `interface{}` to `any`

### DIFF
--- a/pkg/cmd.go
+++ b/pkg/cmd.go
@@ -63,7 +63,7 @@ func LoadConfig(cmd *cobra.Command) (*Config, error) {
 		}
 	}
 
-	if err := k.Load(posflag.ProviderWithFlag(cmd.Flags(), ".", k, func(f *pflag.Flag) (string, interface{}) {
+	if err := k.Load(posflag.ProviderWithFlag(cmd.Flags(), ".", k, func(f *pflag.Flag) (string, any) {
 		if !f.Changed && f.Value.Type() == "bool" {
 			// ignore boolean flags that are not explicitly set
 			// this allows "schemaRoot.additionalProperties" to stay as null when unset

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -432,7 +432,7 @@ func TestGenerateJsonSchema_AdditionalProperties(t *testing.T) {
 		name                   string
 		noAdditionalProperties bool
 		additionalProperties   *bool
-		expected               interface{}
+		expected               any
 	}{
 		{
 			name:                 "AdditionalProperties set to true",
@@ -485,7 +485,7 @@ func TestGenerateJsonSchema_AdditionalProperties(t *testing.T) {
 			generatedBytes, err := os.ReadFile(config.Output)
 			assert.NoError(t, err)
 
-			var generatedSchema map[string]interface{}
+			var generatedSchema map[string]any
 			err = json.Unmarshal(generatedBytes, &generatedSchema)
 			assert.NoError(t, err)
 

--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -83,9 +83,9 @@ type Schema struct {
 	Description           string             `json:"description,omitempty" yaml:"description,omitempty"`
 	Comment               string             `json:"$comment,omitempty" yaml:"$comment,omitempty"`
 	ReadOnly              bool               `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
-	Default               interface{}        `json:"default,omitempty" yaml:"default,omitempty"`
+	Default               any        `json:"default,omitempty" yaml:"default,omitempty"`
 	Ref                   string             `json:"$ref,omitempty" yaml:"$ref,omitempty"`
-	Type                  interface{}        `json:"type,omitempty" yaml:"type,omitempty"`
+	Type                  any        `json:"type,omitempty" yaml:"type,omitempty"`
 	Enum                  []any              `json:"enum,omitempty" yaml:"enum,omitempty"`
 	AllOf                 []*Schema          `json:"allOf,omitempty" yaml:"allOf,omitempty"`
 	AnyOf                 []*Schema          `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`
@@ -228,7 +228,7 @@ func (s *Schema) UnmarshalYAML(value *yaml.Node) error {
 }
 
 // MarshalYAML implements [yaml.Marshaler].
-func (s *Schema) MarshalYAML() (interface{}, error) {
+func (s *Schema) MarshalYAML() (any, error) {
 	switch s.Kind() {
 	case SchemaKindTrue:
 		return true, nil
@@ -332,11 +332,11 @@ func getComments(keyNode, valNode *yaml.Node) []string {
 	return comments
 }
 
-func processList(comment string, stringsOnly bool) []interface{} {
+func processList(comment string, stringsOnly bool) []any {
 	comment = strings.Trim(comment, "[]")
 	items := strings.Split(comment, ",")
 
-	var list []interface{}
+	var list []any
 	for _, item := range items {
 		trimmedItem := strings.TrimSpace(item)
 		if !stringsOnly && trimmedItem == "null" {
@@ -425,7 +425,7 @@ func processComment(schema *Schema, commentLines []string) (isRequired, isHidden
 				schema.ReadOnly = v
 			}
 		case "default":
-			var jsonObject interface{}
+			var jsonObject any
 			if err := json.Unmarshal([]byte(value), &jsonObject); err == nil {
 				schema.Default = jsonObject
 			}

--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -83,9 +83,9 @@ type Schema struct {
 	Description           string             `json:"description,omitempty" yaml:"description,omitempty"`
 	Comment               string             `json:"$comment,omitempty" yaml:"$comment,omitempty"`
 	ReadOnly              bool               `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
-	Default               any        `json:"default,omitempty" yaml:"default,omitempty"`
+	Default               any                `json:"default,omitempty" yaml:"default,omitempty"`
 	Ref                   string             `json:"$ref,omitempty" yaml:"$ref,omitempty"`
-	Type                  any        `json:"type,omitempty" yaml:"type,omitempty"`
+	Type                  any                `json:"type,omitempty" yaml:"type,omitempty"`
 	Enum                  []any              `json:"enum,omitempty" yaml:"enum,omitempty"`
 	AllOf                 []*Schema          `json:"allOf,omitempty" yaml:"allOf,omitempty"`
 	AnyOf                 []*Schema          `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`

--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -645,55 +645,55 @@ func TestProcessList(t *testing.T) {
 		name         string
 		comment      string
 		stringsOnly  bool
-		expectedList []interface{}
+		expectedList []any
 	}{
 		{
 			name:         "empty list",
 			comment:      "[]",
 			stringsOnly:  false,
-			expectedList: []interface{}{""},
+			expectedList: []any{""},
 		},
 		{
 			name:         "single string",
 			comment:      "[\"value\"]",
 			stringsOnly:  true,
-			expectedList: []interface{}{"value"},
+			expectedList: []any{"value"},
 		},
 		{
 			name:         "single string without quotes",
 			comment:      "[value]",
 			stringsOnly:  true,
-			expectedList: []interface{}{"value"},
+			expectedList: []any{"value"},
 		},
 		{
 			name:         "multiple strings",
 			comment:      "[\"value1\", \"value2\"]",
 			stringsOnly:  true,
-			expectedList: []interface{}{"value1", "value2"},
+			expectedList: []any{"value1", "value2"},
 		},
 		{
 			name:         "null allowed",
 			comment:      "[null]",
 			stringsOnly:  false,
-			expectedList: []interface{}{nil},
+			expectedList: []any{nil},
 		},
 		{
 			name:         "null not treated as special",
 			comment:      "[null]",
 			stringsOnly:  true,
-			expectedList: []interface{}{"null"},
+			expectedList: []any{"null"},
 		},
 		{
 			name:         "mixed strings and null",
 			comment:      "[\"value1\", null, \"value2\"]",
 			stringsOnly:  false,
-			expectedList: []interface{}{"value1", nil, "value2"},
+			expectedList: []any{"value1", nil, "value2"},
 		},
 		{
 			name:         "whitespace trimming",
 			comment:      "[ value1, value2 ]",
 			stringsOnly:  true,
-			expectedList: []interface{}{"value1", "value2"},
+			expectedList: []any{"value1", "value2"},
 		},
 	}
 


### PR DESCRIPTION
Changes `interface{}` to `any`

This "modernizes" this syntax.

In my PRs I've been using `any`, and so now the code base uses both `interface{}` and `any`. So to normalize it, I suggest changing all uses to `any`
