### PR TITLE
chore: Change changelog parsing

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,23 +40,23 @@ archives:
       - plugin.yaml
 
 checksum:
-  name_template: '{{ .ProjectName }}-checksum.sha'
+  name_template: "{{ .ProjectName }}-checksum.sha"
   algorithm: sha256
 
 changelog:
   sort: asc
   groups:
     - title: Added
-      regexp: '^.*?feature(\([[:word:]]+\))??!?:.+$'
+      regexp: '(?i)^(.*(feature|feat)(\([[:word:]]+\))??!?:|add(ed)? ).+$'
       order: 0
-    - title: "Fixed"
-      regexp: '^.*?bug|fix(\([[:word:]]+\))??!?:.+$'
+    - title: Fixed
+      regexp: '(?i)^(.*(bug|fix|bugfix)(\([[:word:]]+\))??!?:|fix(ed)? ).+$'
       order: 1
     - title: Updated
-      regexp: '^.*?Bump|chore(\([[:word:]]+\))??!?:.+$'
+      regexp: '(?i)^(.*(bump|build)(\([[:word:]]+\))??!?:|update(d)? |bump(ed)? ).+$'
       order: 2
     - title: Docs
-      regexp: '^.*?docs(\([[:word:]]+\))??!?:.+$'
+      regexp: '(?i)^(.*docs(\([[:word:]]+\))??!?:|docs |document(ed)? ).+$'
       order: 3
     - title: Other
       order: 999


### PR DESCRIPTION
I didn't know you used goreleaser for parsing changelogs using conventional commits format. I'll try follow that from now on.

But for past PRs and for when I forget, I think changing the way it parses could make sense.

Changes:

- Do case-insensitive matching
- Allow prefixes like `Add ` & `Fix ` in addition to the `feat:` & `fix:`
- Added `build` to the updates to match the dependabot PR titles
- Removed `chore:` from "Updated" so that they are put into "Other" instead

Example PR titles that will match:

- Added

  - some feature: foobar
  - Feature: foobar
  - feat: foobar
  - Added foobar
  - Add foobar

- Fixed

  - some bug: foobar
  - bug: foobar
  - fix: foobar
  - bugfix: foobar
  - fix foobar
  - Fixed foobar

- Updated

  - some bump: foobar
  - bump: foobar
  - build(deps): bump securego/gosec from 2.22.3 to 2.22.4
  - update foobar
  - updated foobar
  - bump foobar
  - bumped foobar

- Docs

  - some docs: foobar
  - docs: foobar
  - docs for foobar
  - document foobar
  - documented foobar

- Other

  - chore: foobar
  - foobar
