### PR TITLE
feat: show version with `--version` flag or `version` subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Binaries for programs and plugins
+/helm-values-schema-json
 *.exe
 *.exe~
 *.dll

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,7 +25,7 @@ builds:
       - arm64
     ldflags:
       - -s -w
-        -X main.Version={{ .Tag }}
+        -X main.Version=v{{ .Version }}
         -X main.GitCommit={{ .Commit }}
         -X main.BuildDate={{ .Date }}
     binary: schema

--- a/main.go
+++ b/main.go
@@ -3,15 +3,56 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
+	"strings"
 
 	"github.com/losisin/helm-values-schema-json/v2/pkg"
 )
 
+// This is set by goreleaser using ldflags
+var Version string
+
 func main() {
 	cmd := pkg.NewCmd()
+	cmd.Version = getVersion()
+	pkg.HTTPLoaderDefaultUserAgent = fmt.Sprintf("helm-values-schema-json/%s", cmd.Version)
+
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
 	if err := cmd.Execute(); err != nil {
 		fmt.Println("Error:", err)
 	}
+}
+
+func getVersion() string {
+	if Version != "" {
+		return "v" + strings.TrimPrefix(Version, "v")
+	}
+	return getVersionFromBuildInfo(debug.ReadBuildInfo())
+}
+
+func getVersionFromBuildInfo(info *debug.BuildInfo, ok bool) string {
+	if !ok {
+		return "(devel)" // same string used by Go when running `go run .`
+	}
+	if info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	var revision string
+	var dirty bool
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			revision = setting.Value
+		case "vcs.modified":
+			dirty = setting.Value == "true"
+		}
+	}
+	if revision != "" {
+		if dirty {
+			return revision + "-dirty"
+		}
+		return revision
+	}
+	return "(devel)"
 }

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"runtime/debug"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -138,6 +139,81 @@ func TestMain(t *testing.T) {
 			}
 			if err := os.Remove("values.schema.json"); err != nil && !os.IsNotExist(err) {
 				t.Errorf("failed to remove values.schema.json: %v", err)
+			}
+		})
+	}
+}
+
+func TestGetVersion(t *testing.T) {
+	Version = "v1.2.3"
+	assert.Equal(t, "v1.2.3", getVersion())
+
+	Version = "1.2.3"
+	assert.Equal(t, "v1.2.3", getVersion())
+
+	Version = ""
+	assert.Equal(t, "(devel)", getVersion())
+}
+
+func TestGetVersionFromBuildInfo(t *testing.T) {
+	Version = ""
+	tests := []struct {
+		name    string
+		version string
+		info    *debug.BuildInfo
+		want    string
+	}{
+		{
+			name: "nil",
+			info: nil,
+			want: "(devel)",
+		},
+		{
+			name: "main version",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "v4.5.6"},
+			},
+			want: "v4.5.6",
+		},
+		{
+			name: "vcs revision",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "(devel)"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "some-sha-value"},
+				},
+			},
+			want: "some-sha-value",
+		},
+		{
+			name: "vcs dirty revision",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "(devel)"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "some-sha-value"},
+					{Key: "vcs.modified", Value: "true"},
+				},
+			},
+			want: "some-sha-value-dirty",
+		},
+		{
+			name: "no vcs",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "(devel)"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: ""},
+					{Key: "vcs.modified", Value: "false"},
+				},
+			},
+			want: "(devel)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getVersionFromBuildInfo(tt.info, tt.info != nil)
+			if got != tt.want {
+				t.Errorf("wrong result\nwant: %q\ngot:  %q", tt.want, got)
 			}
 		})
 	}

--- a/pkg/cmd.go
+++ b/pkg/cmd.go
@@ -34,9 +34,10 @@ func NewCmd() *cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "version for helm schema",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			version := cmp.Or(cmd.Root().Version, "(unset)")
-			fmt.Fprintf(cmd.OutOrStdout(), "%s version %s\n", cmd.Root().DisplayName(), version)
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "%s version %s\n", cmd.Root().DisplayName(), version)
+			return err
 		},
 	}
 	cmd.AddCommand(versionCmd)

--- a/pkg/cmd.go
+++ b/pkg/cmd.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"cmp"
 	"fmt"
 	"os"
 
@@ -24,7 +25,21 @@ func NewCmd() *cobra.Command {
 		},
 		SilenceErrors: true,
 		SilenceUsage:  true,
+
+		Annotations: map[string]string{
+			cobra.CommandDisplayNameAnnotation: "helm schema",
+		},
 	}
+
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "version for helm schema",
+		Run: func(cmd *cobra.Command, args []string) {
+			version := cmp.Or(cmd.Root().Version, "(unset)")
+			fmt.Fprintf(cmd.OutOrStdout(), "%s version %s\n", cmd.Root().DisplayName(), version)
+		},
+	}
+	cmd.AddCommand(versionCmd)
 
 	cmd.PersistentFlags().String("config", ".schema.yaml", "Config file for setting defaults.")
 

--- a/pkg/cmd_test.go
+++ b/pkg/cmd_test.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"bytes"
 	"os"
 	"strings"
 	"testing"
@@ -14,40 +15,49 @@ func TestExecute(t *testing.T) {
 		name    string
 		args    []string
 		wantErr string
+		wantOut string
 	}{
 		{
 			name: "success",
-			args: []string{
-				"--values=../testdata/basic.yaml",
-				"--output=/dev/null",
-			},
+			args: []string{"--values=../testdata/basic.yaml", "--output=/dev/null"},
 		},
 		{
-			name: "fail reading config",
-			args: []string{
-				"--config=nonexisting.yaml",
-			},
+			name:    "fail reading config",
+			args:    []string{"--config=nonexisting.yaml"},
 			wantErr: "open nonexisting.yaml: no such file or directory",
 		},
 		{
-			name: "fail execution",
-			args: []string{
-				"--values=/non/existing/file.yaml",
-			},
+			name:    "fail execution",
+			args:    []string{"--values=/non/existing/file.yaml"},
 			wantErr: "error reading YAML file(s)",
+		},
+		{
+			name:    "version flag",
+			args:    []string{"--version"},
+			wantOut: "helm schema version test\n",
+		},
+		{
+			name:    "version subcommand",
+			args:    []string{"version"},
+			wantOut: "helm schema version test\n",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := NewCmd()
-			require.NoError(t, cmd.ParseFlags(tt.args))
+			cmd.Version = "test"
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs(tt.args)
 			err := cmd.Execute()
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
 			} else {
 				assert.NoError(t, err)
 			}
+			assert.Equal(t, tt.wantOut, buf.String())
 		})
 	}
 }

--- a/pkg/loader.go
+++ b/pkg/loader.go
@@ -202,16 +202,20 @@ func (loader CacheLoader) Load(ctx context.Context, ref *url.URL) (*Schema, erro
 type HTTPLoader struct {
 	client    *http.Client
 	SizeLimit int64
+	UserAgent string
 }
 
 func NewHTTPLoader(client *http.Client) HTTPLoader {
 	return HTTPLoader{
 		client:    client,
 		SizeLimit: 200 * 1000 * 1000, // arbitrary limit, but prevents CLI from eating all RAM
+		UserAgent: HTTPLoaderDefaultUserAgent,
 	}
 }
 
 var _ Loader = HTTPLoader{}
+
+var HTTPLoaderDefaultUserAgent = ""
 
 var yamlMediaTypeRegexp = regexp.MustCompile(`^application/(.*\+)?yaml$`)
 
@@ -242,8 +246,8 @@ func (loader HTTPLoader) Load(ctx context.Context, ref *url.URL) (*Schema, error
 			req.Header.Add("Link", fmt.Sprintf(`<%s>; rel="describedby"`, referrer))
 		}
 	}
-	if req.Header.Get("User-Agent") == "" {
-		req.Header.Set("User-Agent", "helm-values-schema-json/1")
+	if loader.UserAgent != "" {
+		req.Header.Set("User-Agent", loader.UserAgent)
 	}
 
 	start := time.Now()

--- a/pkg/loader_test.go
+++ b/pkg/loader_test.go
@@ -260,7 +260,10 @@ func TestHTTPLoader(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name+"/simple", func(t *testing.T) {
 			t.Parallel()
+
+			var gotUserAgent string
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				gotUserAgent = req.Header.Get("User-Agent")
 				if tt.responseType != "" {
 					w.Header().Add("Content-Type", tt.responseType)
 				}
@@ -273,9 +276,12 @@ func TestHTTPLoader(t *testing.T) {
 			ctx := t.Context()
 
 			loader := NewHTTPLoader(server.Client())
+			loader.UserAgent = "test/" + t.Name()
 			schema, err := loader.Load(ctx, mustParseURL(server.URL))
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, schema, "Schema")
+
+			assert.Equal(t, "test/"+t.Name(), gotUserAgent, "User-Agent")
 		})
 
 		t.Run(tt.name+"/gzip", func(t *testing.T) {


### PR DESCRIPTION
- Changed goreleaser to use `v{{ .Version }}` instead of `v{{ .Tag }}` so it includes the snapshot suffix, if any (basically only matters when running goreleaser locally)
- Set command version from either:
  - goreleaser, when building with goreleaser
  - main module version, when installing using `go install github.com/...@latest`
  - or lastly from version-control info, when building using `go build`
- Show version using `--version` flag
- Show version using `version` subcommand
- Use version in HTTPLoader User-Agent

Closes #184
