### PR TITLE
feat: Examples in `--help` text

### DIFF
--- a/pkg/cmd.go
+++ b/pkg/cmd.go
@@ -15,6 +15,25 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "helm schema",
 		Args: cobra.NoArgs,
+		Example: `  # Reads values.yaml and outputs to values.schema.json
+  helm schema
+
+  # Reads from other-values.yaml (only) and outputs to values.schema.json
+  helm schema -f other-values.yaml
+
+  # Reads from multiple files, either comma-separated or use flag multiple times
+  helm schema -f values_1.yaml,values_2.yaml
+  helm schema -f values_1.yaml -f values_2.yaml
+
+  # Bundle schemas mentioned by one of these comment formats:
+  #   myField: {} # @schema $ref: file://some/file/relative/to/values/file
+  #   myField: {} # @schema $ref: some/file/relative/to/values/file
+  #   myField: {} # @schema $ref: https://example.com/schema.json
+  helm schema --bundle
+
+  # Use descriptions from helm-docs
+  # https://github.com/norwoodj/helm-docs
+  helm schema --use-helm-docs`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, err := LoadConfig(cmd)
 			if err != nil {


### PR DESCRIPTION
Shows examples in the `--help` text.

Demo:

```console
$ go run . --help
Usage:
  helm schema [flags]

Examples:
  # Reads values.yaml and outputs to values.schema.json
  helm schema

  # Reads from other-values.yaml (only) and outputs to values.schema.json
  helm schema -f other-values.yaml

  # Reads from multiple files, either comma-separated or use flag multiple times
  helm schema -f values_1.yaml,values_2.yaml
  helm schema -f values_1.yaml -f values_2.yaml

  # Bundle schemas mentioned by one of these comment formats:
  #   myField: {} # @schema $ref: file://some/file/relative/to/values/file
  #   myField: {} # @schema $ref: some/file/relative/to/values/file
  #   myField: {} # @schema $ref: https://example.com/schema.json
  helm schema --bundle

  # Use descriptions from helm-docs
  # https://github.com/norwoodj/helm-docs
  helm schema --use-helm-docs

Flags:
      --bundle                              Bundle referenced ($ref) subschemas into a single file inside $defs
      --bundle-root string                  Root directory to allow local referenced files to be loaded from (default current working directory)
      --bundle-without-id                   Bundle without using $id to reference bundled schemas, which improves compatibility with e.g the VS Code JSON extension
      --config string                       Config file for setting defaults. (default ".schema.yaml")
      --draft int                           Draft version (4, 6, 7, 2019, or 2020) (default 2020)
  -h, --help                                help for helm
      --indent int                          Indentation spaces (even number) (default 4)
      --k8s-schema-url string               URL template used in $ref: $k8s/... alias (default "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/{{ .K8sSchemaVersion }}/")
      --k8s-schema-version string           Version used in the --k8s-schema-url template for $ref: $k8s/... alias
      --no-additional-properties            Default additionalProperties to false for all objects in the schema
  -o, --output string                       Output file path (default "values.schema.json")
      --schema-root.additional-properties   Allow additional properties
      --schema-root.description string      JSON schema description
      --schema-root.id string               JSON schema ID
      --schema-root.ref string              JSON schema URI reference. Relative to current working directory when using "-bundle true".
      --schema-root.title string            JSON schema title
      --use-helm-docs                       Read description from https://github.com/norwoodj/helm-docs comments
  -f, --values strings                      One or more YAML files as inputs. Use comma-separated list or supply flag multiple times (default [values.yaml])
```
