### PR TITLE
chore: Remove double-naming in --help text

### DIFF
--- a/pkg/cmd.go
+++ b/pkg/cmd.go
@@ -14,7 +14,7 @@ import (
 
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:  "helm schema",
+		Use:  "helm",
 		Args: cobra.NoArgs,
 		Example: `  # Reads values.yaml and outputs to values.schema.json
   helm schema


### PR DESCRIPTION
In #188 I changed the display name to `helm schema`, but the `cmd.Use` already had `helm schema`.

This caused some double-naming. So to fix it we only use `helm` in `cmd.Use`. We still want `helm schema` in the display name because otherwise `helm schema --version` would print `helm version v1.2.3` instead of `helm schema version v1.2.3`

Before:

```console
$ go run . --help
Usage:
  helm schema schema [flags]
  helm schema [command]
```

After

```console
$ go run . --help
Usage:
  helm schema [flags]
  helm schema [command]
```
