### PR TITLE
docs: Upgrade notes for v1 -> v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,24 @@
 [![GitHub release (with filter)](https://img.shields.io/github/v/release/losisin/helm-values-schema-json)](https://github.com/losisin/helm-values-schema-json/releases)
 ![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/losisin/helm-values-schema-json/total)
 
-
 Helm plugin for generating `values.schema.json` from single or multiple values files. Schema can be enriched by reading annotations from comments. Works only with Helm3 charts.
 
 ## Installation
 
 ```bash
-$ helm plugin install https://github.com/losisin/helm-values-schema-json.git
-Installed plugin: schema
+helm plugin install https://github.com/losisin/helm-values-schema-json.git
 ```
+
+## Upgrading
+
+```bash
+helm plugin update schema
+```
+
+See changelogs:
+
+- [Breaking changes](./docs/upgrading.md)
+- [Full release notes in GitHub Releases](https://github.com/losisin/helm-values-schema-json/releases)
 
 ## Features
 
@@ -26,9 +35,8 @@ Installed plugin: schema
 - Read description from [helm-docs](https://github.com/norwoodj/helm-docs)
 - Bundling subschemas referenced in `$ref`
 
-See [docs](https://github.com/losisin/helm-values-schema-json/tree/main/docs)
-for more info or checkout example yaml files in
-[testdata](https://github.com/losisin/helm-values-schema-json/tree/main/testdata).
+See [docs](./docs/README.md) for more info or checkout example yaml files
+in [testdata](./testdata).
 
 ## Integrations
 
@@ -139,10 +147,12 @@ Flags:
 
 ### Configuration file
 
-This plugin will look for it's configuration file called `.schema.yaml` in the current working directory. All options available from CLI can be set in this file. Example:
+Uses `.schema.yaml` in the current working directory.
+Example:
 
 ```yaml
-# Required
+# .schema.yaml
+
 values:
   - values.yaml
 
@@ -157,10 +167,19 @@ schemaRoot:
   additionalProperties: true
 ```
 
+All options available from CLI can be set in this file.
+However, do note that the file uses camelCase, while the flags uses kebab-case.
+
 Then, just run the plugin without any arguments:
 
 ```bash
-$ helm schema
+helm schema
+```
+
+You can override which config file to use with the `--config` flag:
+
+```bash
+helm schema --config ./my-helm-schema-config.yaml
 ```
 
 ### CLI
@@ -170,7 +189,7 @@ $ helm schema
 In most cases you will want to run the plugin with default options:
 
 ```bash
-$ helm schema --values values.yaml
+$ helm schema
 ```
 
 This will read `values.yaml`, set draft version to `2020-12` and save outpout to `values.schema.json`.
@@ -211,7 +230,7 @@ deep:
 Run the following command to merge the yaml files and output json schema:
 
 ```bash
-$ helm schema --values values_1.yaml,custom/path/values_2.yaml --draft 7 --output my.schema.json
+helm schema --values values_1.yaml,custom/path/values_2.yaml --draft 7 --output my.schema.json
 ```
 
 Output will be something like this:
@@ -291,7 +310,7 @@ image:
 ```
 
 ```bash
-$ helm schema --values values.yaml --schema-root.id "https://example.com/schema" --schema-root.ref "schema/product.json" -schema-root.title "My schema" --schema-root.description "This is my schema"
+helm schema --values values.yaml --schema-root.id "https://example.com/schema" --schema-root.ref "schema/product.json" -schema-root.title "My schema" --schema-root.description "This is my schema"
 ```
 
 Generated schema will be:

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -3,4 +3,4 @@
 List of breaking changes introduced in different versions
 and how to remedy them.
 
-- [Upgrade v1.x.x to v2.0.0](./upgrading/v1.x.x-to-v2.0.0.md)
+- [Upgrade v1.9.x to v2.0.x](./upgrading/v1.9-to-v2.0.md)

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,6 @@
+# Breaking changes
+
+List of breaking changes introduced in different versions
+and how to remedy them.
+
+- [Upgrade v1.x.x to v2.0.0](./upgrading/v1.x.x-to-v2.0.0.md)

--- a/docs/upgrading/v1.9-to-v2.0.md
+++ b/docs/upgrading/v1.9-to-v2.0.md
@@ -1,4 +1,4 @@
-# Upgrade `helm schema` to v2.0.0
+# Upgrade `helm schema` from v1.9 to v2.0
 
 Upgrading from any v1.9.x version to v2.0.0.
 

--- a/docs/upgrading/v1.9-to-v2.0.md
+++ b/docs/upgrading/v1.9-to-v2.0.md
@@ -1,6 +1,6 @@
 # Upgrade `helm schema` to v2.0.0
 
-Upgrading from any v1.x.x version to v2.0.0.
+Upgrading from any v1.9.x version to v2.0.0.
 
 ## Flag syntax
 

--- a/docs/upgrading/v1.x.x-to-v2.0.0.md
+++ b/docs/upgrading/v1.x.x-to-v2.0.0.md
@@ -1,0 +1,197 @@
+# Upgrade `helm schema` to v2.0.0
+
+Upgrading from any v1.x.x version to v2.0.0.
+
+## Flag syntax
+
+Previously supported either with one or two dashes (e.g `-help` & `--help`),
+but now requires two dashes.
+Some flags has also gained a shorthand, like `-h` for `--help`:
+
+```diff
+- helm schema -help
++ helm schema --help
++ helm schema -h
+```
+
+Internally we switched from Go's own [flag](https://pkg.go.dev/flag) package
+over to the [github.com/spf13/pflag](https://pkg.go.dev/github.com/spf13/pflag)
+package, which is the same library used by Helm's flag parsing.
+
+So you can now expect the same flag parsing behavior between Helm and this
+`helm schema` plugin.
+
+## Flag naming format
+
+Flags changed from camelCase to kebab-case:
+
+```diff
+- helm schema -bundle
+- helm schema -bundleRoot
+- helm schema -bundleWithoutID
+- helm schema -draft
+- helm schema -indent
+- helm schema -input
+- helm schema -k8sSchemaURL
+- helm schema -k8sSchemaVersion
+- helm schema -noAdditionalProperties
+- helm schema -output
+- helm schema -schemaRoot.additionalProperties
+- helm schema -schemaRoot.description
+- helm schema -schemaRoot.id
+- helm schema -schemaRoot.ref
+- helm schema -schemaRoot.title
+
++ helm schema --bundle
++ helm schema --bundle-root
++ helm schema --bundle-without-id
++ helm schema --draft
++ helm schema --indent
++ helm schema --input
++ helm schema --k8s-schema-url
++ helm schema --k8s-schema-version
++ helm schema --no-additional-properties
++ helm schema --output
++ helm schema --schema-root.additional-properties
++ helm schema --schema-root.description
++ helm schema --schema-root.id
++ helm schema --schema-root.ref
++ helm schema --schema-root.title
+```
+
+## Flag boolean syntax
+
+Boolean flags previously required an explicit value of `true` or `false`
+and supported the optional equal sign `=`.
+
+But now specifying a boolean flag implicitly means `true`,
+and can only be set to `false` if using the equal sign `=`.
+
+To set value `true`:
+
+```diff
+- helm schema -bundle true
++ helm schema --bundle
++ helm schema --bundle=true
+- helm schema -bundleWithoutID true
++ helm schema --bundle-without-id
++ helm schema --bundle-without-id=true
+- helm schema -noAdditionalProperties true
++ helm schema --no-additional-properties
++ helm schema --no-additional-properties=true
+- helm schema -schemaRoot.additionalProperties true
++ helm schema --schema-root.additional-properties
++ helm schema --schema-root.additional-properties=true
+```
+
+To set value `false`:
+
+```diff
+- helm schema -bundle false
++ helm schema --bundle=false
+- helm schema -bundleWithoutID false
++ helm schema --bundle-without-id=false
+- helm schema -noAdditionalProperties false
++ helm schema --no-additional-properties=false
+- helm schema -schemaRoot.additionalProperties false
++ helm schema --schema-root.additional-properties=false
+```
+
+## Input flag rename
+
+The `-input` flag was changed to `--values` and gained `-f` shorthand.
+It still supports multiple files separated by comma `,`.
+
+```diff
+- helm schema -input file1.yaml,file2.yaml
++ helm schema --values file1.yaml,file2.yaml
++ helm schema -f file1.yaml,file2.yaml
+
+- helm schema -input file1.yaml -input file2.yaml
++ helm schema --values file1.yaml --values file2.yaml
++ helm schema -f file1.yaml -f file2.yaml
+```
+
+## Input flag default
+
+The `-input` flag was previously required to be provided.
+The new `--values`/`-f` flag defaults to `values.yaml`
+
+```diff
+- helm schema -input values.yaml
++ helm schema
+```
+
+## Output flag
+
+The `-output` flag is still called `--output` (now requiring 2 dashes),
+but has gained a `-o` shorthand:
+
+```diff
+- helm schema -output values.schema.json
++ helm schema --output values.schema.json
++ helm schema -o values.schema.json
+```
+
+## Helm docs flag
+
+A new `--use-helm-docs` flag has been added:
+
+```diff
++ helm schema --use-helm-docs
+```
+
+## Version flag
+
+A new `--version`/`-v` flag has been added, along with a `version` subcommand:
+
+```diff
++ helm schema --version
++ helm schema -v
++ helm schema version
+```
+
+This only prints the current version of `helm schema`.
+
+## Config defaults
+
+The config file `.schema.yaml` has stayed the same and still uses camelCase.
+
+However there are some new configs to match the new flags,
+and some defaults changed:
+
+```diff
+-input: []
++values: [ "values.yaml" ]
+
+ draft: 2020
+ indent: 4
+ output: values.schema.json
+
+ bundle: false
+ bundleRoot: ""
+ bundleWithoutID: false
+
+ k8sSchemaURL:  https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/ {{ .K8sSchemaVersion }}/
+ k8sSchemaVersion: "v1.33.1"
+
++useHelmDocs: false
+
+ schemaRoot:
+   id: ""
+   ref: ""
+   title: ""
+   description: ""
+-  additionalProperties: false
++  additionalProperties: null
+```
+
+## Config flag
+
+You can now change which config file to load using the new `--config` flag:
+
+```diff
++ helm schema --config ./my-helm-schema-config.yaml
+```
+
+The default is `.schema.yaml` (same as before)


### PR DESCRIPTION
Adds docs on upgrade notes. I copied the style from etcd because I liked what they did with the diffs: <https://etcd.io/docs/v3.6/upgrades/upgrade_3_6/>

I suggest we edit the v2.0.0 release notes on GitHub releases (once published) to include a link to this.

Other changes:

- Added link to upgrade docs in README
- Changed code blocks in README to not have `$` prefix, as it makes the snippets easier to copy-paste
- Some other misc changes to the repo README.md

Closes #180
