### PR TITLE
chore: Run CI on `main` branch & all PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,10 @@
 name: ci
 on:
-  pull_request:
+  push:
     branches:
       - main
       - v1
+  pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # helm values schema json plugin
 
-[![ci](https://github.com/losisin/helm-values-schema-json/actions/workflows/ci.yaml/badge.svg)](https://github.com/losisin/helm-values-schema-json/actions/workflows/ci.yaml)
+[![ci](https://github.com/losisin/helm-values-schema-json/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/losisin/helm-values-schema-json/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/losisin/helm-values-schema-json/graph/badge.svg?token=0QQVCFJH84)](https://codecov.io/gh/losisin/helm-values-schema-json)
 [![Go Report Card](https://goreportcard.com/badge/github.com/losisin/helm-values-schema-json)](https://goreportcard.com/report/github.com/losisin/helm-values-schema-json)
 [![Static Badge](https://img.shields.io/badge/licence%20-%20MIT-green)](https://github.com/losisin/helm-values-schema-json/blob/main/LICENSE)


### PR DESCRIPTION
Changes:
- Run CI on `main` branch
- Run CI on all PRs instead of only those that target the `main` branch
- Change badge to only show results from `main` branch

Two main motivations for running CI on the `main` branch:
- Then the badge won't show "failing" just because tests in a PR is failing
- Running CI on the `main` branch populates the cache. The GitHub Action cache is not shared between all branches. It only reuses the cache if the cache was created on the same branch or the default branch. Meaning any newly created PR doesn't use any cache at all.

