### PR TITLE
chore: Added logger to improve test output

### DIFF
--- a/pkg/bundle.go
+++ b/pkg/bundle.go
@@ -19,9 +19,7 @@ import (
 //
 // The paths, outputDir & bundleRoot, are only used to change absolute paths
 // into relative paths in a solely cosmetic way.
-func Bundle(schema *Schema, outputDir, bundleRoot string, withoutIDs bool) error {
-	ctx := context.Background()
-
+func Bundle(ctx context.Context, schema *Schema, outputDir, bundleRoot string, withoutIDs bool) error {
 	absOutputDir, err := filepath.Abs(filepath.Dir(outputDir))
 	if err != nil {
 		return fmt.Errorf("output %s: get absolute path: %w", outputDir, err)

--- a/pkg/bundle_test.go
+++ b/pkg/bundle_test.go
@@ -26,7 +26,8 @@ func TestBundleWithLoader_RemoveIDsError(t *testing.T) {
 		withoutIDs   = true
 	)
 
-	err := bundleWithLoader(t.Context(), loader, schema, absOutputDir, withoutIDs)
+	ctx := ContextWithLogger(t.Context(), t)
+	err := bundleWithLoader(ctx, loader, schema, absOutputDir, withoutIDs)
 	assert.ErrorContains(t, err, "remove bundled $id: /$ref: no $defs found that matches $ref=\"foo.json\"")
 }
 
@@ -414,7 +415,8 @@ func TestBundle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := BundleSchema(t.Context(), tt.loader, tt.schema, "/")
+			ctx := ContextWithLogger(t.Context(), t)
+			err := BundleSchema(ctx, tt.loader, tt.schema, "/")
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, tt.schema)
 
@@ -466,7 +468,8 @@ func TestBundle_Errors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := BundleSchema(t.Context(), tt.loader, tt.schema, "/")
+			ctx := ContextWithLogger(t.Context(), t)
+			err := BundleSchema(ctx, tt.loader, tt.schema, "/")
 			assert.EqualError(t, err, tt.wantErr)
 		})
 	}

--- a/pkg/cmd.go
+++ b/pkg/cmd.go
@@ -41,7 +41,7 @@ func NewCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return GenerateJsonSchema(config)
+			return GenerateJsonSchema(cmd.Context(), config)
 		},
 		SilenceErrors: true,
 		SilenceUsage:  true,

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,7 +13,7 @@ import (
 )
 
 // Generate JSON schema
-func GenerateJsonSchema(config *Config) error {
+func GenerateJsonSchema(ctx context.Context, config *Config) error {
 	// Check if the values flag is set
 	if len(config.Values) == 0 {
 		return errors.New("values flag is required")
@@ -109,7 +110,7 @@ func GenerateJsonSchema(config *Config) error {
 	}
 
 	if config.Bundle {
-		if err := Bundle(mergedSchema, config.Output, config.BundleRoot, config.BundleWithoutID); err != nil {
+		if err := Bundle(ctx, mergedSchema, config.Output, config.BundleRoot, config.BundleWithoutID); err != nil {
 			return err
 		}
 	}
@@ -127,10 +128,12 @@ func GenerateJsonSchema(config *Config) error {
 		mergedSchema.AdditionalProperties = &SchemaFalse
 	}
 
-	return WriteOutput(mergedSchema, config.Output, indentString)
+	return WriteOutput(ctx, mergedSchema, config.Output, indentString)
 }
 
-func WriteOutput(mergedSchema *Schema, outputPath, indent string) error {
+func WriteOutput(ctx context.Context, mergedSchema *Schema, outputPath, indent string) error {
+	logger := LoggerFromContext(ctx)
+
 	// If validation is successful, marshal the schema and save to the file
 	jsonBytes, err := json.MarshalIndent(mergedSchema, "", indent)
 	if err != nil {
@@ -143,6 +146,6 @@ func WriteOutput(mergedSchema *Schema, outputPath, indent string) error {
 		return errors.New("error writing schema to file")
 	}
 
-	fmt.Println("JSON schema successfully generated")
+	logger.Log("JSON schema successfully generated")
 	return nil
 }

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -323,7 +323,8 @@ func TestGenerateJsonSchema(t *testing.T) {
 			require.NoError(t, err)
 			tt.config.SchemaRoot.RefReferrer = ReferrerDir(cwd)
 
-			err = GenerateJsonSchema(tt.config)
+			ctx := ContextWithLogger(t.Context(), t)
+			err = GenerateJsonSchema(ctx, tt.config)
 			require.NoError(t, err, "Error from pkg.GenerateJsonSchema")
 
 			generatedBytes, err := os.ReadFile(tt.config.Output)
@@ -515,7 +516,8 @@ func TestGenerateJsonSchema_Errors(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			err := GenerateJsonSchema(tt.config)
+			ctx := ContextWithLogger(t.Context(), t)
+			err := GenerateJsonSchema(ctx, tt.config)
 			assert.Error(t, err)
 			if err != nil {
 				assert.Contains(t, err.Error(), tt.expectedErr.Error())
@@ -532,7 +534,8 @@ func TestGenerateJsonSchema_Errors(t *testing.T) {
 func TestGenerateJsonSchema_AbsInputError(t *testing.T) {
 	testutil.MakeGetwdFail(t)
 
-	err := GenerateJsonSchema(&Config{
+	ctx := ContextWithLogger(t.Context(), t)
+	err := GenerateJsonSchema(ctx, &Config{
 		Values: []string{"foo/bar.yaml"},
 		Draft:  2020,
 		Indent: 4,
@@ -544,7 +547,8 @@ func TestGenerateJsonSchema_AbsOutputError(t *testing.T) {
 	input := testutil.WriteTempFile(t, "values-*.yaml", []byte(""))
 	testutil.MakeGetwdFail(t)
 
-	err := GenerateJsonSchema(&Config{
+	ctx := ContextWithLogger(t.Context(), t)
+	err := GenerateJsonSchema(ctx, &Config{
 		Values: []string{input.Name()}, // unaffected by failing [os.Getwd] because it is an absolute path
 		Output: "foo.json",
 		Draft:  2020,
@@ -558,7 +562,8 @@ func TestGenerateJsonSchema_AbsBundleRootError(t *testing.T) {
 	input := testutil.WriteTempFile(t, "values-*.yaml", []byte(""))
 	testutil.MakeGetwdFail(t)
 
-	err := GenerateJsonSchema(&Config{
+	ctx := ContextWithLogger(t.Context(), t)
+	err := GenerateJsonSchema(ctx, &Config{
 		Values:     []string{input.Name()}, // unaffected by failing [os.Getwd] because it is an absolute path
 		Output:     "/tmp/foo.json",        // unaffected by failing [os.Getwd] because it is an absolute path
 		Draft:      2020,
@@ -621,7 +626,8 @@ func TestGenerateJsonSchema_AdditionalProperties(t *testing.T) {
 				},
 			}
 
-			err := GenerateJsonSchema(config)
+			ctx := ContextWithLogger(t.Context(), t)
+			err := GenerateJsonSchema(ctx, config)
 			assert.NoError(t, err)
 
 			generatedBytes, err := os.ReadFile(config.Output)
@@ -648,6 +654,7 @@ func TestGenerateJsonSchema_AdditionalProperties(t *testing.T) {
 func TestWriteOutput_JSONError(t *testing.T) {
 	schema := &Schema{Type: func() {}}
 
-	err := WriteOutput(schema, os.DevNull, "  ")
+	ctx := ContextWithLogger(t.Context(), t)
+	err := WriteOutput(ctx, schema, os.DevNull, "  ")
 	require.ErrorContains(t, err, "unsupported type: func()")
 }

--- a/pkg/log.go
+++ b/pkg/log.go
@@ -1,0 +1,61 @@
+package pkg
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+)
+
+type loggerContextKey int
+
+var loggerContextValue = loggerContextKey(1)
+
+// Logger is an interface that allows writing log messages to the user.
+//
+// The interface is intentionally shaped to also allow [testing.T] as a logger.
+type Logger interface {
+	// Prints message as a line.
+	// No need to suffix with a newline.
+	Log(a ...any)
+	// Prints formatted message as a line.
+	// No need to suffix with a newline.
+	Logf(format string, a ...any)
+}
+
+// ContextWithLogger returns a derived context that sets the current logger.
+// This logger is later retrieved using [LoggerFromContext].
+func ContextWithLogger(parent context.Context, logger Logger) context.Context {
+	return context.WithValue(parent, loggerContextValue, logger)
+}
+
+// LoggerFromContext tries to find the current logger from the context,
+// and if none set then will return a new logger that uses [os.Stdout].
+func LoggerFromContext(ctx context.Context) Logger {
+	logger := ctx.Value(loggerContextValue)
+	if logger == nil {
+		return NewLogger(os.Stdout)
+	}
+	return logger.(Logger)
+}
+
+// NewLogger returns a new logger using the provided writer.
+func NewLogger(output io.Writer) WriterLogger {
+	return WriterLogger{output}
+}
+
+// WriterLogger is a [Logger] implementation that writes to a [io.Writer].
+type WriterLogger struct {
+	Output io.Writer
+}
+
+// ensures it implements the interface
+var _ Logger = WriterLogger{}
+
+func (logger WriterLogger) Log(a ...any) {
+	_, _ = fmt.Fprintln(logger.Output, a...)
+}
+
+func (logger WriterLogger) Logf(format string, a ...any) {
+	_, _ = fmt.Fprintf(logger.Output, format+"\n", a...)
+}

--- a/pkg/log_test.go
+++ b/pkg/log_test.go
@@ -1,0 +1,40 @@
+package pkg
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriterLogger(t *testing.T) {
+	t.Run("log", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := NewLogger(&buf)
+		logger.Log("hello", "there")
+		assert.Equal(t, "hello there\n", buf.String())
+	})
+
+	t.Run("logf", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := NewLogger(&buf)
+		logger.Logf("hello %q", "there")
+		assert.Equal(t, "hello \"there\"\n", buf.String())
+	})
+
+	t.Run("default logger from empty context", func(t *testing.T) {
+		logger := LoggerFromContext(context.Background())
+		require.IsType(t, WriterLogger{}, logger)
+		assert.Same(t, os.Stdout, logger.(WriterLogger).Output)
+	})
+
+	t.Run("logger from context", func(t *testing.T) {
+		ctx := ContextWithLogger(context.Background(), NewLogger(nil))
+		logger := LoggerFromContext(ctx)
+		require.IsType(t, WriterLogger{}, logger)
+		assert.Nil(t, logger.(WriterLogger).Output)
+	})
+}


### PR DESCRIPTION
Adds logger interface that allows using `testing.T.Log` during tests, but uses `os.Stdout` in normal execution.

Now when 1 test fails, you won't get all the output from the other tests anymore, which makes it much more readable. This will help when debugging #191 

Added bonus is that the logs in the test results show which line caused the log:

```
=== RUN   TestHTTPLoader_Cache/sends_new_request_if_etag_save_fails
    loader.go:266: Loading http://127.0.0.1:35741
    loader.go:313: Error using etag cache: dummy error
    loader.go:366: Error saving response cache: dummy error
    loader.go:376: => got 2B in 0s
```

Closes #182
