### PR TITLE
feat: Support for `examples`, and support for complex types in lists like `enum`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -93,6 +93,7 @@ The following annotations are supported:
 * [Meta-Data Annotations](#meta-data-annotations)
     * [title and description](#title-and-description)
     * [helm-docs](#helm-docs)
+    * [examples](#examples)
     * [default](#default)
     * [readOnly](#readonly)
 * [Schema Composition](#schema-composition)
@@ -171,7 +172,7 @@ app: &app
 
 ### Enum
 
-Always returns array of strings. Special case is `null` where instead of string, it is treated as valid input type. [section 6.1.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.2)
+Array of JSON values. [section 6.1.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.2)
 
 ```yaml
 service: ClusterIP # @schema enum:[ClusterIP, LoadBalancer, null]
@@ -201,10 +202,10 @@ port: [80, 443] # @schema itemEnum:[80, 8080, 443, 8443]
     "items": {
         "type": "number",
         "enum": [
-            "80",
-            "443",
-            "8080",
-            "8443"
+            80,
+            443,
+            8080,
+            8443
         ]
     },
     "type": [
@@ -804,6 +805,25 @@ nameOverride: "myapp"
 nameOverride: "myapp"
 ```
 
+### examples
+
+(since v2.1.0)
+
+Array of JSON values. [section 9.5](https://json-schema.org/draft/2020-12/json-schema-validation#section-9.5)
+
+```yaml
+tag: "" # @schema examples: [v1.2.3, v1.2.3-beta1]
+```
+
+```json
+"tag": {
+    "examples": [
+        "v1.2.3",
+        "v1.2.3-beta1"
+    ],
+    "type": "string"
+}
+```
 
 ### default
 

--- a/pkg/comment.go
+++ b/pkg/comment.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"encoding/json"
+	"fmt"
 	"iter"
 	"strconv"
 	"strings"
@@ -95,20 +96,51 @@ func getYAMLKind(value string) string {
 }
 
 func processList(comment string, stringsOnly bool) []any {
-	comment = strings.Trim(comment, "[]")
-	items := strings.Split(comment, ",")
+	if strings.HasPrefix(comment, "[") {
+		var list []any
+		if err := yaml.Unmarshal([]byte(comment), &list); err == nil {
+			if stringsOnly {
+				convertScalarsToString(list)
+			}
+			return list
+		}
+	}
+
+	if withoutLeft, ok := strings.CutPrefix(comment, "["); ok {
+		comment = strings.TrimSuffix(withoutLeft, "]")
+	}
 
 	var list []any
-	for _, item := range items {
+	for item := range strings.SplitSeq(comment, ",") {
 		trimmedItem := strings.TrimSpace(item)
 		if !stringsOnly && trimmedItem == "null" {
 			list = append(list, nil)
-		} else {
-			trimmedItem = strings.Trim(trimmedItem, "\"")
-			list = append(list, trimmedItem)
+			continue
 		}
+		if strings.HasPrefix(item, "\"") {
+			var unquoted string
+			if _, err := fmt.Sscanf("%q", item, &unquoted); err == nil {
+				list = append(list, unquoted)
+				continue
+			}
+		}
+		trimmedItem = strings.Trim(trimmedItem, "\"")
+		list = append(list, trimmedItem)
 	}
 	return list
+}
+
+func convertScalarsToString(slice []any) {
+	for i, v := range slice {
+		switch v := v.(type) {
+		case nil:
+			slice[i] = "null"
+		case int, float64, bool:
+			slice[i] = fmt.Sprint(v)
+		case []any:
+			convertScalarsToString(v)
+		}
+	}
 }
 
 func processComment(schema *Schema, commentLines []string) (isRequired, isHidden bool) {
@@ -177,11 +209,17 @@ func processComment(schema *Schema, commentLines []string) (isRequired, isHidden
 				isRequired = true
 			}
 		case "type":
-			schema.Type = processList(value, true)
+			list := processList(value, true)
+			schema.Type = list
+			if len(list) == 1 {
+				schema.Type = list[0]
+			}
 		case "title":
 			schema.Title = value
 		case "description":
 			schema.Description = value
+		case "examples":
+			schema.Examples = processList(value, false)
 		case "readOnly":
 			if v, err := strconv.ParseBool(value); err == nil {
 				schema.ReadOnly = v
@@ -192,11 +230,16 @@ func processComment(schema *Schema, commentLines []string) (isRequired, isHidden
 				schema.Default = jsonObject
 			}
 		case "item":
-			schema.Items = &Schema{
-				Type: value,
+			if schema.Items == nil {
+				schema.Items = &Schema{}
+			}
+			list := processList(value, true)
+			schema.Items.Type = list
+			if len(list) == 1 {
+				schema.Items.Type = list[0]
 			}
 		case "itemProperties":
-			if schema.Items.Type == "object" {
+			if schema.Items.IsType("object") {
 				var itemProps map[string]*Schema
 				if err := json.Unmarshal([]byte(value), &itemProps); err == nil {
 					schema.Items.Properties = itemProps

--- a/pkg/comment_test.go
+++ b/pkg/comment_test.go
@@ -327,19 +327,31 @@ func TestProcessList(t *testing.T) {
 			name:         "empty list",
 			comment:      "[]",
 			stringsOnly:  false,
-			expectedList: []any{""},
+			expectedList: []any{},
 		},
 		{
-			name:         "single string",
+			name:         "JSON string",
 			comment:      "[\"value\"]",
 			stringsOnly:  true,
 			expectedList: []any{"value"},
 		},
 		{
-			name:         "single string without quotes",
+			name:         "YAML string",
 			comment:      "[value]",
 			stringsOnly:  true,
 			expectedList: []any{"value"},
+		},
+		{
+			name:         "JSON string with escapes",
+			comment:      "[\"foo\\\"bar\\\"moo\"]",
+			stringsOnly:  true,
+			expectedList: []any{"foo\"bar\"moo"},
+		},
+		{
+			name:         "single string without quotes",
+			comment:      "[: this is not YAML :]",
+			stringsOnly:  true,
+			expectedList: []any{": this is not YAML :"},
 		},
 		{
 			name:         "multiple strings",
@@ -354,10 +366,22 @@ func TestProcessList(t *testing.T) {
 			expectedList: []any{nil},
 		},
 		{
-			name:         "null not treated as special",
+			name:         "null as string",
 			comment:      "[null]",
 			stringsOnly:  true,
 			expectedList: []any{"null"},
+		},
+		{
+			name:         "numbers allowed",
+			comment:      "[123]",
+			stringsOnly:  false,
+			expectedList: []any{123},
+		},
+		{
+			name:         "numbers as string",
+			comment:      "[123]",
+			stringsOnly:  true,
+			expectedList: []any{"123"},
 		},
 		{
 			name:         "mixed strings and null",
@@ -366,10 +390,28 @@ func TestProcessList(t *testing.T) {
 			expectedList: []any{"value1", nil, "value2"},
 		},
 		{
+			name:         "mixed strings and string null",
+			comment:      "[\"value1\", null, \"value2\"]",
+			stringsOnly:  true,
+			expectedList: []any{"value1", "null", "value2"},
+		},
+		{
 			name:         "whitespace trimming",
 			comment:      "[ value1, value2 ]",
 			stringsOnly:  true,
 			expectedList: []any{"value1", "value2"},
+		},
+		{
+			name:         "trailing comma",
+			comment:      "[value1, value2,]",
+			stringsOnly:  true,
+			expectedList: []any{"value1", "value2"},
+		},
+		{
+			name:         "list of lists",
+			comment:      "[[foo], [bar, null]]",
+			stringsOnly:  true,
+			expectedList: []any{[]any{"foo"}, []any{"bar", "null"}},
 		},
 	}
 
@@ -435,7 +477,7 @@ func TestProcessComment(t *testing.T) {
 			name:             "Set array only item enum",
 			schema:           &Schema{},
 			comment:          "# @schema itemEnum:[1,2]",
-			expectedSchema:   &Schema{Items: &Schema{Enum: []any{"1", "2"}}},
+			expectedSchema:   &Schema{Items: &Schema{Enum: []any{1, 2}}},
 			expectedRequired: false,
 		},
 		{
@@ -499,6 +541,13 @@ func TestProcessComment(t *testing.T) {
 			schema:           &Schema{},
 			comment:          "# @schema not:{\"type\":\"string\"}",
 			expectedSchema:   &Schema{Not: &Schema{Type: "string"}},
+			expectedRequired: false,
+		},
+		{
+			name:             "Set examples",
+			schema:           &Schema{},
+			comment:          "# @schema examples:[foo, bar]",
+			expectedSchema:   &Schema{Examples: []any{"foo", "bar"}},
 			expectedRequired: false,
 		},
 	}

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -57,7 +57,7 @@ func TestGenerateJsonSchema(t *testing.T) {
 			config: &Config{
 				Draft:            2020,
 				Indent:           4,
-				K8sSchemaURL:     "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/{{ .K8sSchemaVersion }}/",
+				K8sSchemaURL:     "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{ .K8sSchemaVersion }}/",
 				K8sSchemaVersion: "v1.33.1",
 				Values: []string{
 					"../testdata/k8sRef.yaml",
@@ -489,7 +489,7 @@ func TestGenerateJsonSchema_Errors(t *testing.T) {
 				},
 				Output: "../testdata/fail-type_output.json",
 			},
-			expectedErr: errors.New("/properties/nameOverride/type/0: invalid type \"foobar\", must be one of: array, boolean, integer, null, number, object, string"),
+			expectedErr: errors.New("/properties/nameOverride/type: invalid type \"foobar\", must be one of: array, boolean, integer, null, number, object, string"),
 		},
 		{
 			name: "invalid helm-docs comment",

--- a/pkg/parser.go
+++ b/pkg/parser.go
@@ -90,6 +90,9 @@ func mergeSchemas(dest, src *Schema) *Schema {
 	if src.Comment != "" {
 		dest.Comment = src.Comment
 	}
+	if src.Examples != nil {
+		dest.Examples = src.Examples
+	}
 	if src.AllOf != nil {
 		dest.AllOf = src.AllOf
 	}

--- a/pkg/parser_test.go
+++ b/pkg/parser_test.go
@@ -10,35 +10,46 @@ import (
 
 // schemasEqual is a helper function to compare two Schema objects.
 func schemasEqual(a, b *Schema) bool {
-	if a == nil || b == nil {
+	switch {
+	case a == nil, b == nil:
 		return a == b
-	}
+
 	// Compare simple fields
-	if a.Type != b.Type || a.Pattern != b.Pattern || a.UniqueItems != b.UniqueItems || a.Title != b.Title || a.Description != b.Description || a.ReadOnly != b.ReadOnly {
+	case a.Type != b.Type,
+		a.Pattern != b.Pattern,
+		a.UniqueItems != b.UniqueItems,
+		a.Title != b.Title,
+		a.Description != b.Description,
+		a.ReadOnly != b.ReadOnly:
 		return false
-	}
+
 	// Compare pointer fields
-	if !comparePointer(a.MultipleOf, b.MultipleOf) ||
-		!comparePointer(a.Maximum, b.Maximum) ||
-		!comparePointer(a.Minimum, b.Minimum) ||
-		!comparePointer(a.MaxLength, b.MaxLength) ||
-		!comparePointer(a.MinLength, b.MinLength) ||
-		!comparePointer(a.MaxItems, b.MaxItems) ||
-		!comparePointer(a.MinItems, b.MinItems) ||
-		!comparePointer(a.MaxProperties, b.MaxProperties) ||
-		!comparePointer(a.MinProperties, b.MinProperties) {
+	case !comparePointer(a.MultipleOf, b.MultipleOf),
+		!comparePointer(a.Maximum, b.Maximum),
+		!comparePointer(a.Minimum, b.Minimum),
+		!comparePointer(a.MaxLength, b.MaxLength),
+		!comparePointer(a.MinLength, b.MinLength),
+		!comparePointer(a.MaxItems, b.MaxItems),
+		!comparePointer(a.MinItems, b.MinItems),
+		!comparePointer(a.MaxProperties, b.MaxProperties),
+		!comparePointer(a.MinProperties, b.MinProperties):
 		return false
-	}
+
 	// Compare slice fields
-	if !reflect.DeepEqual(a.Enum, b.Enum) || !reflect.DeepEqual(a.Required, b.Required) {
+	case !reflect.DeepEqual(a.Type, b.Type),
+		!reflect.DeepEqual(a.Enum, b.Enum),
+		!reflect.DeepEqual(a.Required, b.Required),
+		!reflect.DeepEqual(a.Examples, b.Examples):
 		return false
-	}
+
 	// Recursively check nested fields
-	if !schemasEqual(a.Items, b.Items) {
+	case !schemasEqual(a.Items, b.Items):
 		return false
+
+	default:
+		// Compare map fields (Properties)
+		return reflect.DeepEqual(a.Properties, b.Properties)
 	}
-	// Compare map fields (Properties)
-	return reflect.DeepEqual(a.Properties, b.Properties)
 }
 
 func TestMergeSchemas(t *testing.T) {
@@ -182,9 +193,9 @@ func TestMergeSchemas(t *testing.T) {
 		},
 		{
 			name: "meta-data properties",
-			dest: &Schema{Type: "object", Title: "My Title", Description: "My description", ReadOnly: true, Default: "default value", ID: "http://example.com/schema", Ref: "schema/product.json", Schema: "https://my-schema", Comment: "Lorem ipsum"},
-			src:  &Schema{Type: "object", Title: "My Title", Description: "My description", ReadOnly: true, Default: "default value", ID: "http://example.com/schema", Ref: "schema/product.json", Schema: "https://my-schema", Comment: "Lorem ipsum"},
-			want: &Schema{Type: "object", Title: "My Title", Description: "My description", ReadOnly: true, Default: "default value", ID: "http://example.com/schema", Ref: "schema/product.json", Schema: "https://my-schema", Comment: "Lorem ipsum"},
+			dest: &Schema{Type: "object", Title: "My Title", Description: "My description", ReadOnly: true, Default: "default value", ID: "http://example.com/schema", Ref: "schema/product.json", Schema: "https://my-schema", Comment: "Old comment", Examples: []any{"foo", 1}},
+			src:  &Schema{Type: "object", Title: "My Title", Description: "My description", ReadOnly: true, Default: "default value", ID: "http://example.com/schema", Ref: "schema/product.json", Schema: "https://my-schema", Comment: "New comment", Examples: []any{"bar"}},
+			want: &Schema{Type: "object", Title: "My Title", Description: "My description", ReadOnly: true, Default: "default value", ID: "http://example.com/schema", Ref: "schema/product.json", Schema: "https://my-schema", Comment: "New comment", Examples: []any{"bar"}},
 		},
 		{
 			name: "allOf",

--- a/pkg/parser_test.go
+++ b/pkg/parser_test.go
@@ -265,13 +265,18 @@ func TestEnsureCompliant(t *testing.T) {
 			wantErr: "/type: invalid type \"foobar\", must be one of: array, boolean, integer, null, number, object, string",
 		},
 		{
+			name:    "invalid type string in array",
+			schema:  &Schema{Type: []any{"object", "foobar"}},
+			wantErr: "/type/1: invalid type \"foobar\", must be one of: array, boolean, integer, null, number, object, string",
+		},
+		{
 			name:    "duplicate type",
 			schema:  &Schema{Type: []any{"string", "string"}},
 			wantErr: "/type/1: type list must be unique, but found \"string\" multiple times",
 		},
 		{
 			name:    "invalid type array",
-			schema:  &Schema{Type: []any{true}},
+			schema:  &Schema{Type: []any{[]any{}}},
 			wantErr: "/type/0: type list must only contain strings",
 		},
 		{

--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -81,6 +81,7 @@ type Schema struct {
 	Title                 string             `json:"title,omitempty" yaml:"title,omitempty"`
 	Description           string             `json:"description,omitempty" yaml:"description,omitempty"`
 	Comment               string             `json:"$comment,omitempty" yaml:"$comment,omitempty"`
+	Examples              []any              `json:"$examples,omitempty" yaml:"$examples,omitempty"`
 	ReadOnly              bool               `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
 	Default               any                `json:"default,omitempty" yaml:"default,omitempty"`
 	Ref                   string             `json:"$ref,omitempty" yaml:"$ref,omitempty"`
@@ -130,6 +131,7 @@ func (s *Schema) IsZero() bool {
 		len(s.Title) > 0,
 		len(s.Description) > 0,
 		len(s.Comment) > 0,
+		len(s.Examples) > 0,
 		s.ReadOnly,
 		s.Default != nil,
 		len(s.Ref) > 0,

--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -81,7 +81,7 @@ type Schema struct {
 	Title                 string             `json:"title,omitempty" yaml:"title,omitempty"`
 	Description           string             `json:"description,omitempty" yaml:"description,omitempty"`
 	Comment               string             `json:"$comment,omitempty" yaml:"$comment,omitempty"`
-	Examples              []any              `json:"$examples,omitempty" yaml:"$examples,omitempty"`
+	Examples              []any              `json:"examples,omitempty" yaml:"examples,omitempty"`
 	ReadOnly              bool               `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
 	Default               any                `json:"default,omitempty" yaml:"default,omitempty"`
 	Ref                   string             `json:"$ref,omitempty" yaml:"$ref,omitempty"`
@@ -262,6 +262,20 @@ func (s *Schema) SetKind(kind SchemaKind) {
 		s.kind = SchemaKindObject
 	default:
 		panic(fmt.Errorf("Schema.SetKind(%#v): unexpected kind", kind))
+	}
+}
+
+func (s *Schema) IsType(typ string) bool {
+	switch value := s.Type.(type) {
+	case []any:
+		for _, v := range value {
+			if v == typ {
+				return true
+			}
+		}
+		return false
+	default:
+		return value == typ
 	}
 }
 

--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -452,6 +452,28 @@ func TestGetYAMLKind(t *testing.T) {
 	}
 }
 
+func TestSchemaIsType(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *Schema
+		typ    string
+		want   bool
+	}{
+		{name: "empty", schema: &Schema{}, typ: "string", want: false},
+		{name: "string equal", schema: &Schema{Type: "string"}, typ: "string", want: true},
+		{name: "string not equal", schema: &Schema{Type: "integer"}, typ: "string", want: false},
+		{name: "slice contains", schema: &Schema{Type: []any{"boolean", "string"}}, typ: "string", want: true},
+		{name: "slice not contains", schema: &Schema{Type: []any{"boolean", "integer"}}, typ: "string", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.schema.IsType(tt.typ)
+			assert.Equalf(t, tt.want, got, "Type: %#v", tt.schema.Type)
+		})
+	}
+}
+
 func TestGetSchemaURL(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -80,6 +80,7 @@ func TestSchemaIsZero(t *testing.T) {
 		{name: "Title", schema: &Schema{Title: exampleString}},
 		{name: "Description", schema: &Schema{Description: exampleString}},
 		{name: "Comment", schema: &Schema{Comment: exampleString}},
+		{name: "Examples", schema: &Schema{Examples: exampleAnySlice}},
 		{name: "ReadOnly", schema: &Schema{ReadOnly: exampleBool}},
 		{name: "Default", schema: &Schema{Default: exampleString}},
 		{name: "Ref", schema: &Schema{Ref: exampleString}},

--- a/testdata/anchors.schema.json
+++ b/testdata/anchors.schema.json
@@ -11,9 +11,7 @@
                         "namespace": {
                             "type": "array",
                             "items": {
-                                "type": [
-                                    "string"
-                                ]
+                                "type": "string"
                             }
                         }
                     }

--- a/testdata/full.schema.json
+++ b/testdata/full.schema.json
@@ -73,6 +73,10 @@
                                                     "type": "object",
                                                     "properties": {
                                                         "key": {
+                                                            "examples": [
+                                                                "topology.kubernetes.io/zone",
+                                                                "kubernetes.io/hostname"
+                                                            ],
                                                             "type": "string"
                                                         },
                                                         "operator": {

--- a/testdata/full.yaml
+++ b/testdata/full.yaml
@@ -38,7 +38,7 @@ affinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
         - matchExpressions:
-            - key: topology.kubernetes.io/zone
+            - key: topology.kubernetes.io/zone # @schema examples: [topology.kubernetes.io/zone, kubernetes.io/hostname]
               operator: In
               values:
                 - antarctica-east1

--- a/testdata/helm-docs/values.schema.json
+++ b/testdata/helm-docs/values.schema.json
@@ -46,9 +46,7 @@
         },
         "replicas": {
             "description": "Number of replicas",
-            "type": [
-                "integer"
-            ]
+            "type": "integer"
         },
         "service": {
             "description": "Kubernetes Service type",

--- a/testdata/k8sRef.schema.json
+++ b/testdata/k8sRef.schema.json
@@ -3,7 +3,7 @@
     "type": "object",
     "properties": {
         "memory": {
-            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.33.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.1/_definitions.json#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
             "type": "string"
         }
     }


### PR DESCRIPTION
- Added examples schema field
- Added way to set examples via comments
- Updated `processList` to allow complex types like `@schema examples: [{foo: 1}, {foo: 2}]`

Closes #203
