### PR TITLE
feat: Schema comment parsing errors & better parsing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -379,8 +379,15 @@ dummyList: # @schema minItems:2
 
 Boolean. [section 6.4.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.3)
 
+The `:true` part of `uniqueItems:true` is optional.
+
 ```yaml
 dummyList: # @schema uniqueItems:true
+  - "item1"
+  - "item2"
+  - "item3"
+
+otherList: # @schema uniqueItems
   - "item1"
   - "item2"
   - "item3"
@@ -388,6 +395,13 @@ dummyList: # @schema uniqueItems:true
 
 ```json
 "dummyList": {
+    "items": {
+        "type": "string"
+    },
+    "type": "array",
+    "uniqueItems": true
+},
+"otherList": {
     "items": {
         "type": "string"
     },
@@ -444,10 +458,12 @@ nodeSelector: # @schema minProperties:1
 
 Array of unique strings appended to the parent node. [section 6.5.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.3)
 
+The `:true` part of `required:true` is optional.
+
 ```yaml
 image:
   repository: "nginx" # @schema required:true
-  tag: "latest" # @schema required:true
+  tag: "latest" # @schema required
   imagePullPolicy: "IfNotPresent"
 ```
 
@@ -499,7 +515,7 @@ image: # @schema patternProperties: {"^[a-z]$": {"type": "string"}}
 
 ### additionalProperties
 
-Boolean. [section 10.3.2.3](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.3.2.3)
+JSON Schema object or boolean. [section 10.3.2.3](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.3.2.3)
 
 ```yaml
 image: # @schema additionalProperties: false
@@ -518,15 +534,33 @@ image: # @schema additionalProperties: false
 }
 ```
 
+```yaml
+image: {} # @schema additionalProperties: {type: string}
+```
+
+```json
+"image": {
+    "additionalProperties": {
+        "type": "string"
+    },
+    "type": "object"
+}
+```
+
 ## Unevaluated Locations
 
 ### unevaluatedProperties
 
 Boolean. [section 11.3](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-11.3)
 
+The `:true` part of `unevaluatedProperties:true` is optional.
+
 ```yaml
 image: # @schema unevaluatedProperties: false
   repository: "nginx"
+
+secrets: # @schema unevaluatedProperties
+  foo: "bar"
 ```
 
 ```json
@@ -534,6 +568,15 @@ image: # @schema unevaluatedProperties: false
     "unevaluatedProperties": false,
     "properties": {
         "repository": {
+            "type": "string"
+        }
+    },
+    "type": "object"
+},
+"secrets": {
+    "unevaluatedProperties": true,
+    "properties": {
+        "foo": {
             "type": "string"
         }
     },
@@ -851,14 +894,21 @@ tolerations: [] # @schema default: [{"key":"foo","operator":"Equal","value":"bar
 
 Boolean. [section 9.4](https://json-schema.org/draft/2020-12/json-schema-validation#section-9.4)
 
+The `:true` part of `readOnly:true` is optional.
+
 ```yaml
 image:
-  tag: latest # @schema readOnly: true
+  repository: "nginx" # @schema readOnly:true
+  tag: "latest" # @schema readOnly
 ```
 
 ```json
 "image": {
     "properties": {
+        "repository": {
+            "readOnly": true,
+            "type": "string"
+        },
         "tag": {
             "readOnly": true,
             "type": "string"

--- a/docs/README.md
+++ b/docs/README.md
@@ -490,10 +490,10 @@ image:
 
 ### patternProperties
 
-JSON string added "AS IS" to the node. [section 10.3.2.2](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.3.2.2)
+YAML object added "AS IS" to the node. [section 10.3.2.2](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.3.2.2)
 
 ```yaml
-image: # @schema patternProperties: {"^[a-z]$": {"type": "string"}}
+image: # @schema patternProperties: {"^[a-z]$": {type: string}}
   repository: "nginx"
 ```
 
@@ -515,7 +515,7 @@ image: # @schema patternProperties: {"^[a-z]$": {"type": "string"}}
 
 ### additionalProperties
 
-JSON Schema object or boolean. [section 10.3.2.3](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.3.2.3)
+YAML object of a Schema or boolean. [section 10.3.2.3](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.3.2.3)
 
 ```yaml
 image: # @schema additionalProperties: false
@@ -870,10 +870,10 @@ tag: "" # @schema examples: [v1.2.3, v1.2.3-beta1]
 
 ### default
 
-Any JSON value. [section 9.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-9.2)
+Any YAML value. [section 9.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-9.2)
 
 ```yaml
-tolerations: [] # @schema default: [{"key":"foo","operator":"Equal","value":"bar","effect":"NoSchedule"}]
+tolerations: [] # @schema default: [{key: foo, operator: Equal, value: bar, effect: NoSchedule}]
 ```
 
 ```json
@@ -924,11 +924,11 @@ Keywords for Applying Subschemas With Logic. Field `"type"` is dropped and you M
 
 ### allOf
 
-Non-empty array. Each item of the array MUST be a valid JSON Schema. [section 10.2.1.1](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.2.1.1)
+Non-empty YAML array. Each item of the array MUST be a valid Schema. [section 10.2.1.1](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.2.1.1)
 
 ```yaml
 image:
-  digest: sha256:1234567890 # @schema allOf: [{"type": "string"}, {"minLength": 14}]
+  digest: sha256:1234567890 # @schema allOf: [{type: string}, {minLength: 14}]
 ```
 
 ```json
@@ -951,12 +951,12 @@ image:
 
 ### anyOf
 
-Non-empty array. Each item of the array MUST be a valid JSON Schema. [section 10.2.1.2](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.2.1.2)
+Non-empty YAML array. Each item of the array MUST be a valid Schema. [section 10.2.1.2](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.2.1.2)
 
 ```yaml
 cluster:
   enabled: true
-  nodes: 3 # @schema anyOf: [{"type": "number", "multipleOf": 3}, {"type": "number", "multipleOf": 5}]
+  nodes: 3 # @schema anyOf: [{type: number, multipleOf: 3}, {type: number, multipleOf: 5}]
 ```
 
 ```json
@@ -984,12 +984,12 @@ cluster:
 
 ### oneOf
 
-Non-empty array. Each item of the array MUST be a valid JSON Schema. [section 10.2.1.3](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.2.1.3)
+Non-empty YAML array. Each item of the array MUST be a valid Schema. [section 10.2.1.3](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.2.1.3)
 
 ```yaml
 MY_SECRET:
   ref: "secret-reference-in-manager"
-  version: # @schema oneOf: [{"type": "string"}, {"type": "number"}]
+  version: # @schema oneOf: [{type: string}, {type: number}]
 ```
 
 ```json
@@ -1015,11 +1015,11 @@ MY_SECRET:
 
 ### not
 
-A valid JSON Schema. [section 10.2.1.4](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.2.1.4)
+YAML object. MUST be a valid Schema. [section 10.2.1.4](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-10.2.1.4)
 
 ```yaml
 image:
-  tag: latest # @schema not: {"type": "object"}
+  tag: latest # @schema not: {type: object}
 ```
 
 ```json

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -12,9 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Variable is only used to fake which GOOS is set
+var goosOverrideForTests string
+
 func MakeGetwdFail(t *testing.T) {
 	t.Helper()
-	switch runtime.GOOS {
+	switch cmp.Or(goosOverrideForTests, runtime.GOOS) {
 	case "darwin", "windows":
 		t.Skipf("Skipping because don't know how to make os.Getwd fail on GOOS=%s", runtime.GOOS)
 	}
@@ -87,9 +90,6 @@ type PerGOOS struct {
 	Windows string
 	Darwin  string
 }
-
-// Variable is only used to fake which GOOS is set
-var goosOverrideForTests string
 
 func (err PerGOOS) String() string {
 	switch cmp.Or(goosOverrideForTests, runtime.GOOS) {

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -19,6 +19,19 @@ func TestMakeGetwdFail(t *testing.T) {
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
+func TestMakeGetwdFail_skipped(t *testing.T) {
+	goosOverrideForTests = "darwin"
+	defer func() { goosOverrideForTests = "" }()
+
+	var skipped bool
+	t.Run("sub-test", func(t *testing.T) {
+		defer func() { skipped = t.Skipped() }()
+		MakeGetwdFail(t)
+	})
+
+	require.True(t, skipped)
+}
+
 func TestCreateTempFile(t *testing.T) {
 	var file *os.File
 	t.Run("sub-test", func(t *testing.T) {

--- a/pkg/bundle_test.go
+++ b/pkg/bundle_test.go
@@ -415,9 +415,9 @@ func TestBundle(t *testing.T) {
 
 		{
 			name:   "additionalProperties false",
-			schema: &Schema{AdditionalProperties: &SchemaFalse},
+			schema: &Schema{AdditionalProperties: SchemaFalse()},
 			loader: DummyLoader{},
-			want:   &Schema{AdditionalProperties: &SchemaFalse},
+			want:   &Schema{AdditionalProperties: SchemaFalse()},
 		},
 		{
 			name: "additionalProperties schema",

--- a/pkg/comment_test.go
+++ b/pkg/comment_test.go
@@ -792,7 +792,7 @@ func TestProcessUint64PtrComment(t *testing.T) {
 				t.Run(startVal.name, func(t *testing.T) {
 					t.Logf("Comment: %q", tt.comment)
 
-					var got *uint64 = startVal.value
+					got := startVal.value
 					err := processUint64PtrComment(&got, tt.comment)
 					if tt.wantErr != "" {
 						require.ErrorContains(t, err, tt.wantErr)

--- a/pkg/comment_test.go
+++ b/pkg/comment_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -437,139 +438,370 @@ func TestProcessList(t *testing.T) {
 
 func TestProcessComment(t *testing.T) {
 	tests := []struct {
-		name             string
-		schema           *Schema
-		comment          string
-		expectedSchema   *Schema
-		expectedRequired bool
+		name       string
+		schema     *Schema
+		comment    string
+		wantSchema *Schema
 	}{
 		{
-			name:             "Empty comment",
-			schema:           &Schema{},
-			comment:          "# @schema ",
-			expectedSchema:   &Schema{},
-			expectedRequired: false,
+			name:       "Empty comment",
+			schema:     &Schema{},
+			comment:    "# @schema ",
+			wantSchema: &Schema{},
 		},
 		{
-			name:             "Set type",
-			schema:           &Schema{},
-			comment:          "# @schema type:[string, null]",
-			expectedSchema:   &Schema{Type: []any{"string", "null"}},
-			expectedRequired: false,
+			name:       "Set type",
+			schema:     &Schema{},
+			comment:    "# @schema type:[string, null]",
+			wantSchema: &Schema{Type: []any{"string", "null"}},
 		},
 		{
-			name:             "Set enum",
-			schema:           &Schema{},
-			comment:          "# @schema enum:[one, two, null]",
-			expectedSchema:   &Schema{Enum: []any{"one", "two", nil}},
-			expectedRequired: false,
+			name:       "Set enum",
+			schema:     &Schema{},
+			comment:    "# @schema enum:[one, two, null]",
+			wantSchema: &Schema{Enum: []any{"one", "two", nil}},
 		},
 		{
-			name:             "Set numeric",
-			schema:           &Schema{},
-			comment:          "# @schema multipleOf:2;minimum:1;maximum:10",
-			expectedSchema:   &Schema{MultipleOf: float64Ptr(2), Minimum: float64Ptr(1), Maximum: float64Ptr(10)},
-			expectedRequired: false,
+			name:    "Set float integers",
+			schema:  &Schema{},
+			comment: "# @schema multipleOf:2; minimum:1; maximum:10",
+			wantSchema: &Schema{
+				MultipleOf: float64Ptr(2),
+				Minimum:    float64Ptr(1),
+				Maximum:    float64Ptr(10),
+			},
 		},
 		{
-			name:             "Set string",
-			schema:           &Schema{},
-			comment:          "# @schema pattern:^abv$;minLength:2;maxLength:10",
-			expectedSchema:   &Schema{Pattern: "^abv$", MinLength: uint64Ptr(2), MaxLength: uint64Ptr(10)},
-			expectedRequired: false,
+			name:    "Set float decimals",
+			schema:  &Schema{},
+			comment: "# @schema multipleOf:2.5; minimum:1.5; maximum:10.5",
+			wantSchema: &Schema{
+				MultipleOf: float64Ptr(2.5),
+				Minimum:    float64Ptr(1.5),
+				Maximum:    float64Ptr(10.5),
+			},
 		},
 		{
-			name:             "Set array",
-			schema:           &Schema{},
-			comment:          "# @schema minItems:1;maxItems:10;uniqueItems:true;item:object;itemProperties:{\"key\": {\"type\": \"string\"}}",
-			expectedSchema:   &Schema{MinItems: uint64Ptr(1), MaxItems: uint64Ptr(10), UniqueItems: true, Items: &Schema{Type: "object", Properties: map[string]*Schema{"key": {Type: "string"}}}},
-			expectedRequired: false,
+			name:   "Set float back to null",
+			schema: &Schema{},
+			comment: "# @schema multipleOf:2; minimum:1; maximum:10; " +
+				"multipleOf:null; minimum:null; maximum:null",
+			wantSchema: &Schema{
+				MultipleOf: nil,
+				Minimum:    nil,
+				Maximum:    nil,
+			},
 		},
 		{
-			name:             "Set array only item enum",
-			schema:           &Schema{},
-			comment:          "# @schema itemEnum:[1,2]",
-			expectedSchema:   &Schema{Items: &Schema{Enum: []any{1, 2}}},
-			expectedRequired: false,
+			name:    "Set integers",
+			schema:  &Schema{},
+			comment: "# @schema minLength:1; maxLength:2; minItems:3; maxItems:4; minProperties:5; maxProperties:6",
+			wantSchema: &Schema{
+				MinLength:     uint64Ptr(1),
+				MaxLength:     uint64Ptr(2),
+				MinItems:      uint64Ptr(3),
+				MaxItems:      uint64Ptr(4),
+				MinProperties: uint64Ptr(5),
+				MaxProperties: uint64Ptr(6),
+			},
 		},
 		{
-			name:             "Set array item type and enum",
-			schema:           &Schema{},
-			comment:          "# @schema minItems:1;maxItems:10;uniqueItems:true;item:string;itemEnum:[\"one\",\"two\"]",
-			expectedSchema:   &Schema{MinItems: uint64Ptr(1), MaxItems: uint64Ptr(10), UniqueItems: true, Items: &Schema{Type: "string", Enum: []any{"one", "two"}}},
-			expectedRequired: false,
+			name:   "Set integers back to null",
+			schema: &Schema{},
+			comment: "# @schema minLength:1; maxLength:2; minItems:3; maxItems:4; minProperties:5; maxProperties:6; " +
+				"minLength:null; maxLength:null; minItems:null; maxItems:null; minProperties:null; maxProperties:null",
+			wantSchema: &Schema{
+				MinLength:     nil,
+				MaxLength:     nil,
+				MinItems:      nil,
+				MaxItems:      nil,
+				MinProperties: nil,
+				MaxProperties: nil,
+			},
 		},
 		{
-			name:             "Set object",
-			schema:           &Schema{},
-			comment:          "# @schema minProperties:1;maxProperties:10;additionalProperties:false;$id:https://example.com/schema;$ref:schema/product.json",
-			expectedSchema:   &Schema{MinProperties: uint64Ptr(1), MaxProperties: uint64Ptr(10), AdditionalProperties: &SchemaFalse, ID: "https://example.com/schema", Ref: "schema/product.json"},
-			expectedRequired: false,
+			name:       "Set string",
+			schema:     &Schema{},
+			comment:    "# @schema pattern:^abv$;minLength:2;maxLength:10",
+			wantSchema: &Schema{Pattern: "^abv$", MinLength: uint64Ptr(2), MaxLength: uint64Ptr(10)},
 		},
 		{
-			name:             "Set meta-data",
-			schema:           &Schema{},
-			comment:          "# @schema title:My Title;description: some description;readOnly:false;default:\"foo\"",
-			expectedSchema:   &Schema{Title: "My Title", Description: "some description", ReadOnly: false, Default: "foo"},
-			expectedRequired: false,
+			name:       "Set array",
+			schema:     &Schema{},
+			comment:    "# @schema minItems:1;maxItems:10;uniqueItems:true;item:object;itemProperties:{\"key\": {\"type\": \"string\"}}",
+			wantSchema: &Schema{MinItems: uint64Ptr(1), MaxItems: uint64Ptr(10), UniqueItems: true, Items: &Schema{Type: "object", Properties: map[string]*Schema{"key": {Type: "string"}}}},
 		},
 		{
-			name:             "Set skipProperties",
-			schema:           &Schema{},
-			comment:          "# @schema skipProperties:true;unevaluatedProperties:false",
-			expectedSchema:   &Schema{SkipProperties: true, UnevaluatedProperties: boolPtr(false)},
-			expectedRequired: false,
+			name:       "Set array only item enum",
+			schema:     &Schema{},
+			comment:    "# @schema itemEnum:[1,2]",
+			wantSchema: &Schema{Items: &Schema{Enum: []any{1, 2}}},
 		},
 		{
-			name:             "Set hidden",
-			schema:           &Schema{},
-			comment:          "# @schema hidden:true",
-			expectedSchema:   &Schema{},
-			expectedRequired: false,
+			name:       "Set array item type and enum",
+			schema:     &Schema{},
+			comment:    "# @schema minItems:1;maxItems:10;uniqueItems:true;item:string;itemEnum:[\"one\",\"two\"]",
+			wantSchema: &Schema{MinItems: uint64Ptr(1), MaxItems: uint64Ptr(10), UniqueItems: true, Items: &Schema{Type: "string", Enum: []any{"one", "two"}}},
 		},
 		{
-			name:             "Set allOf",
-			schema:           &Schema{},
-			comment:          "# @schema allOf:[{\"type\":\"string\"}]",
-			expectedSchema:   &Schema{AllOf: []*Schema{{Type: "string"}}},
-			expectedRequired: false,
+			name:       "Set object",
+			schema:     &Schema{},
+			comment:    "# @schema minProperties:1;maxProperties:10;additionalProperties:false;$id:https://example.com/schema;$ref:schema/product.json",
+			wantSchema: &Schema{MinProperties: uint64Ptr(1), MaxProperties: uint64Ptr(10), AdditionalProperties: SchemaFalse(), ID: "https://example.com/schema", Ref: "schema/product.json"},
 		},
 		{
-			name:             "Set anyOf",
-			schema:           &Schema{},
-			comment:          "# @schema anyOf:[{\"type\":\"string\"}]",
-			expectedSchema:   &Schema{AnyOf: []*Schema{{Type: "string"}}},
-			expectedRequired: false,
+			name:       "Set additionalProperties object",
+			schema:     &Schema{},
+			comment:    "# @schema additionalProperties:{\"type\":\"string\"}",
+			wantSchema: &Schema{AdditionalProperties: &Schema{Type: "string"}},
 		},
 		{
-			name:             "Set oneOf",
-			schema:           &Schema{},
-			comment:          "# @schema oneOf:[{\"type\":\"string\"}]",
-			expectedSchema:   &Schema{OneOf: []*Schema{{Type: "string"}}},
-			expectedRequired: false,
+			name:       "Set additionalProperties bool empty",
+			schema:     &Schema{},
+			comment:    "# @schema additionalProperties",
+			wantSchema: &Schema{AdditionalProperties: SchemaTrue()},
 		},
 		{
-			name:             "Set not",
-			schema:           &Schema{},
-			comment:          "# @schema not:{\"type\":\"string\"}",
-			expectedSchema:   &Schema{Not: &Schema{Type: "string"}},
-			expectedRequired: false,
+			name:       "Set meta-data",
+			schema:     &Schema{},
+			comment:    "# @schema title:My Title;description: some description;readOnly:false;default:\"foo\"",
+			wantSchema: &Schema{Title: "My Title", Description: "some description", ReadOnly: false, Default: "foo"},
 		},
 		{
-			name:             "Set examples",
-			schema:           &Schema{},
-			comment:          "# @schema examples:[foo, bar]",
-			expectedSchema:   &Schema{Examples: []any{"foo", "bar"}},
-			expectedRequired: false,
+			name:       "Set skipProperties",
+			schema:     &Schema{},
+			comment:    "# @schema skipProperties:true;unevaluatedProperties:false",
+			wantSchema: &Schema{SkipProperties: true, UnevaluatedProperties: boolPtr(false)},
+		},
+		{
+			name:       "Set hidden",
+			schema:     &Schema{},
+			comment:    "# @schema hidden:true",
+			wantSchema: &Schema{Hidden: true},
+		},
+		{
+			name:       "Set and unset hidden",
+			schema:     &Schema{},
+			comment:    "# @schema hidden:true; hidden:false",
+			wantSchema: &Schema{Hidden: false},
+		},
+		{
+			name:       "Set required",
+			schema:     &Schema{},
+			comment:    "# @schema required:true",
+			wantSchema: &Schema{RequiredByParent: true},
+		},
+		{
+			name:       "Set and unset required",
+			schema:     &Schema{},
+			comment:    "# @schema required:true; required:false",
+			wantSchema: &Schema{RequiredByParent: false},
+		},
+		{
+			name:       "Set allOf",
+			schema:     &Schema{},
+			comment:    "# @schema allOf:[{\"type\":\"string\"}]",
+			wantSchema: &Schema{AllOf: []*Schema{{Type: "string"}}},
+		},
+		{
+			name:       "Set anyOf",
+			schema:     &Schema{},
+			comment:    "# @schema anyOf:[{\"type\":\"string\"}]",
+			wantSchema: &Schema{AnyOf: []*Schema{{Type: "string"}}},
+		},
+		{
+			name:       "Set oneOf",
+			schema:     &Schema{},
+			comment:    "# @schema oneOf:[{\"type\":\"string\"}]",
+			wantSchema: &Schema{OneOf: []*Schema{{Type: "string"}}},
+		},
+		{
+			name:       "Set not JSON",
+			schema:     &Schema{},
+			comment:    "# @schema not:{\"type\":\"string\"}",
+			wantSchema: &Schema{Not: &Schema{Type: "string"}},
+		},
+		{
+			name:       "Set examples",
+			schema:     &Schema{},
+			comment:    "# @schema examples:[foo, bar]",
+			wantSchema: &Schema{Examples: []any{"foo", "bar"}},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var required bool
-			processComment(tt.schema, []string{tt.comment})
-			assert.Equal(t, tt.expectedSchema, tt.schema)
-			assert.Equal(t, tt.expectedRequired, required)
+			err := processComment(tt.schema, []string{tt.comment})
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSchema, tt.schema)
+		})
+	}
+}
+
+func TestProcessComment_Error(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		wantErr string
+	}{
+		{name: "unknown annotation", comment: "# @schema foobar: 123", wantErr: "unknown annotation \"foobar\""},
+
+		{name: "required invalid bool", comment: "# @schema required: foo", wantErr: "required: invalid boolean"},
+		{name: "readOnly invalid bool", comment: "# @schema readOnly: foo", wantErr: "readOnly: invalid boolean"},
+		{name: "hidden invalid bool", comment: "# @schema hidden: foo", wantErr: "hidden: invalid boolean"},
+		{name: "required invalid bool", comment: "# @schema required: foo", wantErr: "required: invalid boolean"},
+		{name: "uniqueItems invalid bool", comment: "# @schema uniqueItems: foo", wantErr: "uniqueItems: invalid boolean"},
+		{name: "skipProperties invalid bool", comment: "# @schema skipProperties: foo", wantErr: "skipProperties: invalid boolean"},
+		{name: "unevaluatedProperties invalid bool", comment: "# @schema unevaluatedProperties: foo", wantErr: "unevaluatedProperties: invalid boolean"},
+
+		{name: "maxLength invalid uint64", comment: "# @schema maxLength: foo", wantErr: "maxLength: invalid integer"},
+		{name: "minLength invalid uint64", comment: "# @schema minLength: foo", wantErr: "minLength: invalid integer"},
+		{name: "maxItems invalid uint64", comment: "# @schema maxItems: foo", wantErr: "maxItems: invalid integer"},
+		{name: "minItems invalid uint64", comment: "# @schema minItems: foo", wantErr: "minItems: invalid integer"},
+		{name: "maxProperties invalid uint64", comment: "# @schema maxProperties: foo", wantErr: "maxProperties: invalid integer"},
+		{name: "minProperties invalid uint64", comment: "# @schema minProperties: foo", wantErr: "minProperties: invalid integer"},
+
+		{name: "multipleOf invalid float64", comment: "# @schema multipleOf: foo", wantErr: "multipleOf: invalid number"},
+		{name: "multipleOf zero", comment: "# @schema multipleOf: 0", wantErr: "multipleOf: must be greater than zero"},
+		{name: "minimum invalid float64", comment: "# @schema minimum: foo", wantErr: "minimum: invalid number"},
+		{name: "maximum invalid float64", comment: "# @schema maximum: foo", wantErr: "maximum: invalid number"},
+
+		{name: "patternProperties invalid YAML", comment: "# @schema patternProperties: {", wantErr: "patternProperties: parse object \"{\": yaml"},
+		{name: "default invalid YAML", comment: "# @schema default: {", wantErr: "default: parse object \"{\": yaml"},
+		{name: "itemProperties invalid YAML", comment: "# @schema itemProperties: {", wantErr: "itemProperties: parse object \"{\": yaml"},
+		{name: "additionalProperties invalid YAML", comment: "# @schema additionalProperties: {", wantErr: "additionalProperties: parse object \"{\": yaml"},
+		{name: "allOf invalid YAML", comment: "# @schema allOf: {", wantErr: "allOf: parse object \"{\": yaml"},
+		{name: "anyOf invalid YAML", comment: "# @schema anyOf: {", wantErr: "anyOf: parse object \"{\": yaml"},
+		{name: "oneOf invalid YAML", comment: "# @schema oneOf: {", wantErr: "oneOf: parse object \"{\": yaml"},
+		{name: "not invalid YAML", comment: "# @schema not: {", wantErr: "not: parse object \"{\": yaml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var schema Schema
+			err := processComment(&schema, []string{tt.comment})
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestProcessObjectComment(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    *Schema
+		wantErr string
+	}{
+		{name: "empty", comment: "", wantErr: "parse object \"\": missing value"},
+		{name: "empty object", comment: "{}", want: &Schema{}},
+		{name: "null", comment: "null", want: nil},
+		{name: "JSON syntax", comment: "{\"type\":\"string\"}", want: &Schema{Type: "string"}},
+		{name: "YAML syntax", comment: "{type: string}", want: &Schema{Type: "string"}},
+		{name: "invalid field", comment: "{\"readOnly\": \"foobar\"}", wantErr: "parse object \"{\\\"readOnly\\\": \\\"foobar\\\"}\": yaml: unmarshal errors:"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Logf("Comment: %q", tt.comment)
+			var got *Schema
+			err := processObjectComment(&got, tt.comment)
+			if tt.wantErr != "" {
+				t.Logf("Unexpected value: %#v", got)
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+
+	t.Run("overrides instead of merges", func(t *testing.T) {
+		schema := &Schema{
+			Minimum: float64Ptr(123),
+		}
+		err := processObjectComment(&schema, "{\"type\": \"string\"}")
+		require.NoError(t, err)
+
+		want := &Schema{
+			Type: "string",
+			// we don't want "Minimum" to stick around
+		}
+		require.Equal(t, want, schema)
+	})
+}
+
+func TestProcessBoolComment(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    bool
+		wantErr string
+	}{
+		{name: "empty", comment: "", want: true},
+		{name: "only spacing", comment: "  \t ", want: true},
+		{name: "true", comment: "true", want: true},
+		{name: "true with spacing", comment: " \t  true  \t ", want: true},
+		{name: "true uppercase", comment: "TRUE", wantErr: "invalid boolean \"TRUE\", must be \"true\" or \"false\""},
+		{name: "false", comment: "false", want: false},
+		{name: "false with spacing", comment: " \t  false \t ", want: false},
+		{name: "false uppercase", comment: "FALSE", wantErr: "invalid boolean \"FALSE\", must be \"true\" or \"false\""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Logf("Comment: %q", tt.comment)
+			var got bool
+			err := processBoolComment(&got, tt.comment)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestProcessUint64PtrComment(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    *uint64
+		wantErr string
+	}{
+		{name: "empty", comment: "", wantErr: "invalid integer \"\": invalid syntax"},
+		{name: "only spacing", comment: "  \t ", wantErr: "invalid integer \"\": invalid syntax"},
+		{name: "null", comment: "null", want: nil},
+		{name: "integer", comment: "123", want: uint64Ptr(123)},
+		{name: "negative integer", comment: "-123", wantErr: "invalid integer \"-123\": negative values not allowed"},
+		{name: "float", comment: "1.23", wantErr: "invalid integer \"1.23\": invalid syntax"},
+		{name: "hex", comment: "0x123", wantErr: "invalid integer \"0x123\": invalid syntax"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			startValues := []struct {
+				name  string
+				value *uint64
+			}{
+				{name: "overriding nil", value: nil},
+				{name: "overriding value", value: uint64Ptr(123)},
+			}
+
+			for _, startVal := range startValues {
+				t.Run(startVal.name, func(t *testing.T) {
+					t.Logf("Comment: %q", tt.comment)
+
+					var got *uint64 = startVal.value
+					err := processUint64PtrComment(&got, tt.comment)
+					if tt.wantErr != "" {
+						require.ErrorContains(t, err, tt.wantErr)
+					} else {
+						require.NoError(t, err)
+						require.Equal(t, tt.want, got)
+					}
+				})
+			}
 		})
 	}
 }

--- a/pkg/parser.go
+++ b/pkg/parser.go
@@ -20,7 +20,7 @@ func mergeSchemas(dest, src *Schema) *Schema {
 	dest.SetKind(src.Kind())
 
 	// Resolve simple fields by favoring the fields from 'src' if they're provided
-	if src.Type != "" {
+	if src.Type != nil {
 		dest.Type = src.Type
 	}
 	if src.MultipleOf != nil {
@@ -116,6 +116,9 @@ func mergeSchemas(dest, src *Schema) *Schema {
 
 	// 'required' array is combined uniquely
 	dest.Required = uniqueStringAppend(dest.Required, src.Required...)
+	if src.RequiredByParent {
+		dest.RequiredByParent = src.RequiredByParent
+	}
 
 	// Merge 'items' if they exist (assuming they're not arrays)
 	if src.Items != nil {
@@ -177,8 +180,8 @@ func ensureCompliantRec(ptr Ptr, schema *Schema, visited map[*Schema]struct{}, n
 		return err
 	}
 
-	if schema.AdditionalProperties == nil && noAdditionalProperties && schema.Type == "object" {
-		schema.AdditionalProperties = &SchemaFalse
+	if schema.AdditionalProperties == nil && noAdditionalProperties && schema.IsType("object") {
+		schema.AdditionalProperties = SchemaFalse()
 	}
 
 	switch {

--- a/pkg/parser_test.go
+++ b/pkg/parser_test.go
@@ -15,8 +15,7 @@ func schemasEqual(a, b *Schema) bool {
 		return a == b
 
 	// Compare simple fields
-	case a.Type != b.Type,
-		a.Pattern != b.Pattern,
+	case a.Pattern != b.Pattern,
 		a.UniqueItems != b.UniqueItems,
 		a.Title != b.Title,
 		a.Description != b.Description,
@@ -187,9 +186,9 @@ func TestMergeSchemas(t *testing.T) {
 		},
 		{
 			name: "object properties",
-			dest: &Schema{Type: "object", MinProperties: uint64Ptr(1), MaxProperties: uint64Ptr(10), PatternProperties: map[string]*Schema{"^.$": {Type: "string"}}, AdditionalProperties: &SchemaFalse, UnevaluatedProperties: boolPtr(false)},
-			src:  &Schema{Type: "object", MinProperties: uint64Ptr(1), MaxProperties: uint64Ptr(10), PatternProperties: map[string]*Schema{"^.$": {Type: "string"}}, AdditionalProperties: &SchemaFalse, UnevaluatedProperties: boolPtr(false)},
-			want: &Schema{Type: "object", MinProperties: uint64Ptr(1), MaxProperties: uint64Ptr(10), PatternProperties: map[string]*Schema{"^.$": {Type: "string"}}, AdditionalProperties: &SchemaFalse, UnevaluatedProperties: boolPtr(false)},
+			dest: &Schema{Type: "object", MinProperties: uint64Ptr(1), MaxProperties: uint64Ptr(10), PatternProperties: map[string]*Schema{"^.$": {Type: "string"}}, AdditionalProperties: SchemaFalse(), UnevaluatedProperties: boolPtr(false)},
+			src:  &Schema{Type: "object", MinProperties: uint64Ptr(1), MaxProperties: uint64Ptr(10), PatternProperties: map[string]*Schema{"^.$": {Type: "string"}}, AdditionalProperties: SchemaFalse(), UnevaluatedProperties: boolPtr(false)},
+			want: &Schema{Type: "object", MinProperties: uint64Ptr(1), MaxProperties: uint64Ptr(10), PatternProperties: map[string]*Schema{"^.$": {Type: "string"}}, AdditionalProperties: SchemaFalse(), UnevaluatedProperties: boolPtr(false)},
 		},
 		{
 			name: "meta-data properties",
@@ -227,6 +226,12 @@ func TestMergeSchemas(t *testing.T) {
 			src:  &Schema{RefReferrer: ReferrerDir("/foo/bar")},
 			want: &Schema{RefReferrer: ReferrerDir("/foo/bar")},
 		},
+		{
+			name: "RequiredByParent",
+			dest: &Schema{RequiredByParent: false},
+			src:  &Schema{RequiredByParent: true},
+			want: &Schema{RequiredByParent: true},
+		},
 	}
 
 	for _, tt := range tests {
@@ -255,8 +260,8 @@ func TestEnsureCompliant(t *testing.T) {
 
 		{
 			name:   "bool schema",
-			schema: &SchemaTrue,
-			want:   &SchemaTrue,
+			schema: SchemaTrue(),
+			want:   SchemaTrue(),
 		},
 
 		{
@@ -294,7 +299,7 @@ func TestEnsureCompliant(t *testing.T) {
 			noAdditionalProperties: true,
 			want: &Schema{
 				Type:                 "object",
-				AdditionalProperties: &SchemaFalse,
+				AdditionalProperties: SchemaFalse(),
 			},
 		},
 


### PR DESCRIPTION
I started with making boolean annotations allow empty strings, but then I started flowing and my changes grew, and grew, and grew. I didn't make intermediate commits, so everything is just bunched up into a single commit.

So instead of just boolean annotations, this PR reworks the comment parsing a bit. Changes:

- BREAKING: Schema comment parsing now errors instead of silently ignoring
  - on invalid value, e.g `# @schema readOnly: 123`
  - and on unknown annotation key, e.g `# @schema foobar: 123`

- Boolean annotations now allow skipping the `true` part, which then implicitly means `true`. For example, these two are now semantically identical:

  ```yaml
  # @schema required: true; hidden true
  # @schema required; hidden
  ```

- Now supports YAML syntax instead of just JSON syntax in more places. For example, these two are now semantically identical:

  ```yaml
  # @schema not: {"type": "string"}
  # @schema not: {type: string}
  ```

- Now supports setting `additionalProperties` to something else than just a boolean:

  ```yaml
  # @schema additionalProperties: {type: string}
  ```

Some internal changes:

- Make use of `Schema.Hidden` and some other internal fields, as the `processComment` return values duplicated that state without any reason I could find.
- Simplified `processComment`'s function signature to just return `error` instead of a couple of booleans
- Added more `processXXXComment` functions to abstract uint64, float64, and object parsing
- Renamed type in marshalling code to improve error messages, as the YAML parser would otherwise print an error message that mentions `pkg.SchemaWithoutMarshaler`, but now says `pkg.schema` which is less confusing for the end user

I do consider the breaking change a fix for a bug. The fact that `helm schema` just _ignored_ `key: value` pairs on any parsing errors is to me a bug. So I don't think this needs a v3.0.0 release. But wdyt?

If we were to do a v3 release, then we should also rename some of the annotations, such as `itemProperties` -> `item/properties` (and maybe make that part more generic to allow more sub references like that)

Closes #207
