### PR TITLE
Exit with non-zero exit code on error

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,9 @@ import (
 // This is set by goreleaser using ldflags
 var Version string
 
+// Using variable to allow mocking this during tests
+var osExit = os.Exit
+
 func main() {
 	cmd := pkg.NewCmd()
 	cmd.Version = getVersion()
@@ -20,7 +23,10 @@ func main() {
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error:", err)
+			osExit(1)
+		}
 	}
 }
 


### PR DESCRIPTION
Makes the plugin correctly exit with a non-zero exit code on error.

This is expected behaviour, and so this PR is treated as a bugfix.

Before:

```console
$ go run . --values foobar
Error: read --values="foobar": error reading YAML file(s): open foobar: no such file or directory

$ echo $?
0
```

After:

```console
$ go run . --values foobar
Error: read --values="foobar": error reading YAML file(s): open foobar: no such file or directory
exit status 1

$ echo $?
1
```

Closes #238
