### PR TITLE
feat: support '.kyaml' extension when bundling local files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -781,6 +781,7 @@ Bundling supports the following schemes:
 
 ```yaml
 ## HTTP & HTTPS
+## NOTE: JSON or YAML parsing is based on the "Content-Type" response header (default: JSON)
 # @schema $ref: http://example.com/schema.json
 # @schema $ref: http://example.com/schema.yaml
 # @schema $ref: https://example.com/schema.json
@@ -788,6 +789,7 @@ Bundling supports the following schemes:
 
 ## Local files
 ## NOTE: "file://" only supports absolute paths
+## NOTE: JSON or YAML parsing is based on file extension (default: JSON)
 # @schema $ref: file:///some/absolute/path.json
 # @schema $ref: file:///some/absolute/path.yaml
 # @schema $ref: /some/absolute/path.json

--- a/pkg/loader.go
+++ b/pkg/loader.go
@@ -162,7 +162,7 @@ func (loader FileLoader) Load(ctx context.Context, ref *url.URL) (*Schema, error
 
 	var schema Schema
 	switch filepath.Ext(path) {
-	case ".yml", ".yaml":
+	case ".yml", ".yaml", ".kyml", ".kyaml":
 		if err := yaml.Unmarshal(b, &schema); err != nil {
 			return nil, fmt.Errorf("parse YAML file: %w", err)
 		}


### PR DESCRIPTION
Kubernetes has developed a new config language called KYAML: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/5295-kyaml

It's just a slimmed down version of YAML. Pure subset.

Our bundler checks the file extension on local files to figure out which parser to use. This PR just adds `.kyaml` & `.kyml` to the list of YAML file extensions.
