### PR TITLE
fix: Bundle should update `$ref` when loaded subschema uses `$id`

### DIFF
--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -300,6 +300,38 @@ func TestGenerateJsonSchema(t *testing.T) {
 		},
 
 		{
+			// https://github.com/losisin/helm-values-schema-json/issues/210
+			name: "bundle/ref-relative-to-id",
+			config: &Config{
+				Draft:      2020,
+				Indent:     4,
+				Bundle:     true,
+				BundleRoot: "..",
+				Values: []string{
+					"../testdata/bundle/ref-relative-to-id.yaml",
+				},
+				Output: "../testdata/bundle/ref-relative-to-id_output.json",
+			},
+			templateSchemaFile: "../testdata/bundle/ref-relative-to-id.schema.json",
+		},
+		{
+			// https://github.com/losisin/helm-values-schema-json/issues/210
+			name: "bundle/ref-relative-to-id-without-id",
+			config: &Config{
+				Draft:           2020,
+				Indent:          4,
+				Bundle:          true,
+				BundleRoot:      "..",
+				BundleWithoutID: true, // <!>
+				Values: []string{
+					"../testdata/bundle/ref-relative-to-id.yaml",
+				},
+				Output: "../testdata/bundle/ref-relative-to-id-without-id_output.json",
+			},
+			templateSchemaFile: "../testdata/bundle/ref-relative-to-id-without-id.schema.json",
+		},
+
+		{
 			name: "helm-docs",
 			config: &Config{
 				Draft:       2020,

--- a/pkg/pointer.go
+++ b/pkg/pointer.go
@@ -72,6 +72,13 @@ func (p Ptr) HasPrefix(prefix Ptr) bool {
 	return slices.Equal(p[:len(prefix)], prefix)
 }
 
+func (p Ptr) CutPrefix(prefix Ptr) (after Ptr, ok bool) {
+	if !p.HasPrefix(prefix) {
+		return p, false
+	}
+	return p[len(prefix):], true
+}
+
 func (p Ptr) Equals(other Ptr) bool {
 	if len(other) != len(p) {
 		return false
@@ -87,4 +94,93 @@ func (p Ptr) Equals(other Ptr) bool {
 //	// => "/foo/bar"
 func (p Ptr) String() string {
 	return "/" + strings.Join(p, "/")
+}
+
+type ResolvedSchema struct {
+	Ptr    Ptr
+	Schema *Schema
+}
+
+// Resolve returns all of the matched subschemas.
+// The last slice element is the deepest subschema along the pointer's path.
+//
+// For example:
+//
+//	Resolve(schema, NewPtr("/$defs/foo/items/type"))
+//	// => []*Schema{ "/$defs", "/$defs/foo", "/$defs/foo/items" }
+func (ptr Ptr) Resolve(schema *Schema) []ResolvedSchema {
+	var result []ResolvedSchema
+	var offset int
+	for schema != nil {
+		result = append(result, ResolvedSchema{ptr[:offset], schema})
+		ptrRest := ptr[offset:]
+
+		if len(ptrRest) == 0 {
+			return result
+		} else if s, ok := ptrRest.resolveField(schema); ok {
+			offset += 1
+			schema = s
+			continue
+		}
+
+		if len(ptrRest) < 2 {
+			return result
+		} else if s, ok := ptrRest.resolveMap(schema); ok {
+			offset += 2
+			schema = s
+		} else if s, ok := ptrRest.resolveSlice(schema); ok {
+			offset += 2
+			schema = s
+		} else {
+			return result
+		}
+	}
+	return result
+}
+
+func (ptr Ptr) resolveField(schema *Schema) (*Schema, bool) {
+	switch ptr[0] {
+	case "additionalItems":
+		return schema.AdditionalItems, true
+	case "additionalProperties":
+		return schema.AdditionalProperties, true
+	case "items":
+		return schema.Items, true
+	case "not":
+		return schema.Not, true
+	default:
+		return nil, false
+	}
+}
+
+func (ptr Ptr) resolveMap(schema *Schema) (*Schema, bool) {
+	switch ptr[0] {
+	case "$defs":
+		return schema.Defs[ptr[1]], true
+	case "definitions":
+		return schema.Definitions[ptr[1]], true
+	case "patternProperties":
+		return schema.PatternProperties[ptr[1]], true
+	case "properties":
+		return schema.Properties[ptr[1]], true
+	default:
+		return nil, false
+	}
+}
+
+func (ptr Ptr) resolveSlice(schema *Schema) (*Schema, bool) {
+	index, err := strconv.Atoi(ptr[1])
+	if err != nil {
+		return nil, false
+	}
+	switch ptr[0] {
+	case "allOf":
+		return tryIndex(schema.AllOf, index), true
+	case "anyOf":
+		return tryIndex(schema.AnyOf, index), true
+	case "oneOf":
+		return tryIndex(schema.OneOf, index), true
+	default:
+		return nil, false
+	}
 }

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -104,3 +104,10 @@ func countOccurrencesSlice[T comparable](slice []T, item T) int {
 	}
 	return count
 }
+
+func tryIndex[T any](slice []*T, index int) *T {
+	if index < 0 || index >= len(slice) {
+		return nil
+	}
+	return slice[index]
+}

--- a/pkg/utils_test.go
+++ b/pkg/utils_test.go
@@ -150,3 +150,34 @@ func TestCountOccurrencesSlice(t *testing.T) {
 		})
 	}
 }
+
+func TestTryIndex(t *testing.T) {
+	var (
+		a = uint64Ptr(1)
+		b = uint64Ptr(2)
+		c = uint64Ptr(3)
+	)
+	tests := []struct {
+		name  string
+		slice []*uint64
+		index int
+		want  *uint64
+	}{
+		{name: "nil 0", slice: nil, index: 0, want: nil},
+		{name: "nil out-of-bound", slice: nil, index: 10, want: nil},
+		{name: "empty 0", slice: []*uint64{}, index: 0, want: nil},
+		{name: "empty out-of-bound", slice: []*uint64{}, index: 10, want: nil},
+		{name: "in-bounds", slice: []*uint64{a, b, c}, index: 1, want: b},
+		{name: "too high", slice: []*uint64{a, b, c}, index: 10, want: nil},
+		{name: "too low", slice: []*uint64{a, b, c}, index: -10, want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tryIndex(tt.slice, tt.index)
+			if got != tt.want {
+				t.Errorf("wrong result\nslice: %#v\nwant: %#v\ngot:  %#v", tt.slice, tt.want, got)
+			}
+		})
+	}
+}

--- a/testdata/bundle/ref-relative-to-id-without-id.schema.json
+++ b/testdata/bundle/ref-relative-to-id-without-id.schema.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "foo": {
+            "$ref": "#/$defs/hello/items",
+            "type": "integer"
+        }
+    },
+    "$defs": {
+        "hello": {
+            "items": {
+                "description": "hello world"
+            }
+        }
+    }
+}

--- a/testdata/bundle/ref-relative-to-id.json
+++ b/testdata/bundle/ref-relative-to-id.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "bar": {
+            "$id": "hello",
+            "items": {
+                "description": "hello world"
+            }
+        }
+    }
+}

--- a/testdata/bundle/ref-relative-to-id.schema.json
+++ b/testdata/bundle/ref-relative-to-id.schema.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "foo": {
+            "$ref": "hello#/items",
+            "type": "integer"
+        }
+    },
+    "$defs": {
+        "hello": {
+            "$id": "hello",
+            "items": {
+                "description": "hello world"
+            }
+        }
+    }
+}

--- a/testdata/bundle/ref-relative-to-id.yaml
+++ b/testdata/bundle/ref-relative-to-id.yaml
@@ -1,0 +1,7 @@
+# Tries to replicate issue https://github.com/losisin/helm-values-schema-json/issues/210
+
+# What's going on here is that the $ref below targets a section of "ref-relative-to-id.json"
+# that uses an $id, and so the "foo: 1"'s $ref should be updated to be relative
+# to that $id instead of relative to the root schema.
+
+foo: 1 # @schema $ref: ./ref-relative-to-id.json#/definitions/bar/items

--- a/testdata/doc.go
+++ b/testdata/doc.go
@@ -25,6 +25,8 @@ package testdata
 //go:generate go run .. --bundle=true --values bundle/namecollision.yaml --output bundle/namecollision.schema.json
 //go:generate go run .. --bundle=true --values bundle/nested.yaml --output bundle/nested-without-id.schema.json --bundle-without-id=true
 //go:generate go run .. --bundle=true --values bundle/nested.yaml --output bundle/nested.schema.json
+//go:generate go run .. --bundle=true --values bundle/ref-relative-to-id.yaml --output bundle/ref-relative-to-id-without-id.schema.json --bundle-without-id=true
+//go:generate go run .. --bundle=true --values bundle/ref-relative-to-id.yaml --output bundle/ref-relative-to-id.schema.json
 //go:generate go run .. --bundle=true --values bundle/simple.yaml --output bundle/simple-absolute-root.schema.json --bundle-root=/
 //go:generate go run .. --bundle=true --values bundle/simple.yaml --output bundle/simple-root-ref.schema.json --schema-root.ref ./bundle/simple-subschema.schema.json
 //go:generate go run .. --bundle=true --values bundle/simple.yaml --output bundle/simple-without-id.schema.json --bundle-without-id=true


### PR DESCRIPTION
This makes some changes to how the bundler deals with `$id` in the loaded schemas.

See explanation of issue in #210

Closes #210
