### PR TITLE
fix: noAdditionalProperties no longer breaks chart usage as dependency

### DIFF
--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -116,18 +116,18 @@ func GenerateJsonSchema(ctx context.Context, config *Config) error {
 		}
 	}
 
+	if config.SchemaRoot.AdditionalProperties != nil {
+		mergedSchema.AdditionalProperties = SchemaBool(*config.SchemaRoot.AdditionalProperties)
+	} else if config.NoAdditionalProperties {
+		mergedSchema.AdditionalProperties = SchemaFalse()
+	}
+
 	// Ensure merged Schema is JSON Schema compliant
 	if err := ensureCompliant(mergedSchema, config.NoAdditionalProperties, config.Draft); err != nil {
 		return err
 	}
 	mergedSchema.Schema = schemaURL // Include the schema draft version
 	mergedSchema.Type = "object"
-
-	if config.SchemaRoot.AdditionalProperties != nil {
-		mergedSchema.AdditionalProperties = SchemaBool(*config.SchemaRoot.AdditionalProperties)
-	} else if config.NoAdditionalProperties {
-		mergedSchema.AdditionalProperties = SchemaFalse()
-	}
 
 	return WriteOutput(ctx, mergedSchema, filepath.FromSlash(config.Output), indentString)
 }

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -29,6 +29,15 @@ func closeIgnoreError(closer io.Closer) {
 	_ = closer.Close()
 }
 
+// hasKey returns true when a map contains the given key.
+// This utility function allows checking that a key exists in boolean switch statements.
+//
+// Will always return false if the map is nil.
+func hasKey[K comparable, V any](m map[K]V, k K) bool {
+	_, ok := m[k]
+	return ok
+}
+
 func iterMapOrdered[K cmp.Ordered, V any](m map[K]V) iter.Seq2[K, V] {
 	return func(yield func(K, V) bool) {
 		for _, k := range slices.Sorted(maps.Keys(m)) {

--- a/testdata/noAdditionalProperties.schema.json
+++ b/testdata/noAdditionalProperties.schema.json
@@ -2,6 +2,14 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
+        "global": {
+            "description": "Global values shared between all subcharts",
+            "$comment": "Added automatically by 'helm schema' to allow this chart to be used as a Helm dependency, as the `additionalProperties` setting would otherwise collide with Helm's special 'global' values key.",
+            "type": [
+                "object",
+                "null"
+            ]
+        },
         "object": {
             "type": "object",
             "additionalProperties": false


### PR DESCRIPTION
Fixes an issue where:

1. Chart A sets `additionalProperties: false` on its schema root
2. Chart B loads chart A as a dependency
3. During `helm template`, Helm injects a `global` property, which breaks chart A's schema, resulting in error:
   ```console
   $ helm template ./chartB
   Error: values don't meet the specifications of the schema(s) in the following chart(s):
   chartA:
   - (root): Additional property global is not allowed
   ```

The solution is to automatically inject a `global` property to allow chart A to be used as a dependency:

```diff
diff --git a/testdata/noAdditionalProperties.schema.json b/testdata/noAdditionalProperties.schema.json
index e7b77fc..9a4eb16 100644
--- a/testdata/noAdditionalProperties.schema.json
+++ b/testdata/noAdditionalProperties.schema.json
@@ -1,35 +1,43 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
+        "global": {
+            "description": "Global values shared between all subcharts",
+            "$comment": "Added automatically by 'helm schema' to allow this chart to be used as a Helm dependency, as the `additionalProperties` setting would otherwise collide with Helm's special 'global' values key.",
+            "type": [
+                "object",
+                "null"
+            ]
+        },
         "object": {
             "type": "object",
             "additionalProperties": false
         },
```

Closes #254
