### PR TITLE
feat: Support all JSON Schema keywords in internal data structure

### DIFF
--- a/pkg/comment.go
+++ b/pkg/comment.go
@@ -262,11 +262,11 @@ func processComment(schema *Schema, commentLines []string) error {
 				return fmt.Errorf("additionalProperties: %w", err)
 			}
 		case "unevaluatedProperties":
-			var b bool
-			if err := processBoolComment(&b, value); err != nil {
+			if strings.TrimSpace(value) == "" {
+				schema.UnevaluatedProperties = SchemaTrue()
+			} else if err := processObjectComment(&schema.UnevaluatedProperties, value); err != nil {
 				return fmt.Errorf("unevaluatedProperties: %w", err)
 			}
-			schema.UnevaluatedProperties = &b
 		case "$id":
 			schema.ID = value
 		case "$ref":

--- a/pkg/comment_test.go
+++ b/pkg/comment_test.go
@@ -569,6 +569,12 @@ func TestProcessComment(t *testing.T) {
 			wantSchema: &Schema{AdditionalProperties: SchemaTrue()},
 		},
 		{
+			name:       "Set unevaluatedProperties bool empty",
+			schema:     &Schema{},
+			comment:    "# @schema unevaluatedProperties",
+			wantSchema: &Schema{UnevaluatedProperties: SchemaTrue()},
+		},
+		{
 			name:       "Set meta-data",
 			schema:     &Schema{},
 			comment:    "# @schema title:My Title;description: some description;readOnly:false;default:\"foo\";const:\"foo\"",
@@ -578,7 +584,7 @@ func TestProcessComment(t *testing.T) {
 			name:       "Set skipProperties",
 			schema:     &Schema{},
 			comment:    "# @schema skipProperties:true;unevaluatedProperties:false",
-			wantSchema: &Schema{SkipProperties: true, UnevaluatedProperties: boolPtr(false)},
+			wantSchema: &Schema{SkipProperties: true, UnevaluatedProperties: SchemaFalse()},
 		},
 		{
 			name:       "Set mergeProperties",
@@ -666,7 +672,6 @@ func TestProcessComment_Error(t *testing.T) {
 		{name: "uniqueItems invalid bool", comment: "# @schema uniqueItems: foo", wantErr: "uniqueItems: invalid boolean"},
 		{name: "skipProperties invalid bool", comment: "# @schema skipProperties: foo", wantErr: "skipProperties: invalid boolean"},
 		{name: "mergeProperties invalid bool", comment: "# @schema mergeProperties: foo", wantErr: "mergeProperties: invalid boolean"},
-		{name: "unevaluatedProperties invalid bool", comment: "# @schema unevaluatedProperties: foo", wantErr: "unevaluatedProperties: invalid boolean"},
 
 		{name: "maxLength invalid uint64", comment: "# @schema maxLength: foo", wantErr: "maxLength: invalid integer"},
 		{name: "minLength invalid uint64", comment: "# @schema minLength: foo", wantErr: "minLength: invalid integer"},
@@ -684,6 +689,7 @@ func TestProcessComment_Error(t *testing.T) {
 		{name: "default invalid YAML", comment: "# @schema default: {", wantErr: "default: parse object \"{\": yaml"},
 		{name: "itemProperties invalid YAML", comment: "# @schema itemProperties: {", wantErr: "itemProperties: parse object \"{\": yaml"},
 		{name: "additionalProperties invalid YAML", comment: "# @schema additionalProperties: {", wantErr: "additionalProperties: parse object \"{\": yaml"},
+		{name: "unevaluatedProperties invalid YAML", comment: "# @schema unevaluatedProperties: {", wantErr: "unevaluatedProperties: parse object \"{\": yaml"},
 		{name: "allOf invalid YAML", comment: "# @schema allOf: {", wantErr: "allOf: parse object \"{\": yaml"},
 		{name: "anyOf invalid YAML", comment: "# @schema anyOf: {", wantErr: "anyOf: parse object \"{\": yaml"},
 		{name: "oneOf invalid YAML", comment: "# @schema oneOf: {", wantErr: "oneOf: parse object \"{\": yaml"},

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -107,7 +107,7 @@ func GenerateJsonSchema(ctx context.Context, config *Config) error {
 
 		// Merge with existing data
 		mergedSchema = mergeSchemas(mergedSchema, tempSchema)
-		mergedSchema.Required = uniqueStringAppend(mergedSchema.Required, required...)
+		mergedSchema.Required = uniqueStringAppend(mergedSchema.Required, required)
 	}
 
 	if config.Bundle {

--- a/pkg/schema.go
+++ b/pkg/schema.go
@@ -79,41 +79,68 @@ type Schema struct {
 	kind SchemaKind
 
 	// Field ordering is taken from https://github.com/sourcemeta/core/blob/429eb970f3e303c3f61ba3cf066c7bd766453e15/src/core/jsonschema/jsonschema.cc#L459-L546
-	Schema                string             `json:"$schema,omitempty" yaml:"$schema,omitempty"`
-	ID                    string             `json:"$id,omitempty" yaml:"$id,omitempty"`
-	Title                 string             `json:"title,omitempty" yaml:"title,omitempty"`
-	Description           string             `json:"description,omitempty" yaml:"description,omitempty"`
-	Comment               string             `json:"$comment,omitempty" yaml:"$comment,omitempty"`
-	Examples              []any              `json:"examples,omitempty" yaml:"examples,omitempty"`
-	ReadOnly              bool               `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
-	Default               any                `json:"default,omitempty" yaml:"default,omitempty"`
-	Ref                   string             `json:"$ref,omitempty" yaml:"$ref,omitempty"`
-	RefReferrer           Referrer           `json:"-" yaml:"-"`
-	Type                  any                `json:"type,omitempty" yaml:"type,omitempty"`
-	Enum                  []any              `json:"enum,omitempty" yaml:"enum,omitempty"`
-	AllOf                 []*Schema          `json:"allOf,omitempty" yaml:"allOf,omitempty"`
-	AnyOf                 []*Schema          `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`
-	OneOf                 []*Schema          `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
-	Not                   *Schema            `json:"not,omitempty" yaml:"not,omitempty"`
-	Maximum               *float64           `json:"maximum,omitempty" yaml:"maximum,omitempty"`
-	Minimum               *float64           `json:"minimum,omitempty" yaml:"minimum,omitempty"`
-	MultipleOf            *float64           `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
-	Pattern               string             `json:"pattern,omitempty" yaml:"pattern,omitempty"`
-	MaxLength             *uint64            `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
-	MinLength             *uint64            `json:"minLength,omitempty" yaml:"minLength,omitempty"`
-	MaxItems              *uint64            `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
-	MinItems              *uint64            `json:"minItems,omitempty" yaml:"minItems,omitempty"`
-	UniqueItems           bool               `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
-	Items                 *Schema            `json:"items,omitempty" yaml:"items,omitempty"`
-	AdditionalItems       *Schema            `json:"additionalItems,omitempty" yaml:"additionalItems,omitempty"`
-	Required              []string           `json:"required,omitempty" yaml:"required,omitempty"`
-	MaxProperties         *uint64            `json:"maxProperties,omitempty" yaml:"maxProperties,omitempty"`
-	MinProperties         *uint64            `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
-	Properties            map[string]*Schema `json:"properties,omitempty" yaml:"properties,omitempty"`
-	PatternProperties     map[string]*Schema `json:"patternProperties,omitempty" yaml:"patternProperties,omitempty"`
-	AdditionalProperties  *Schema            `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
-	UnevaluatedProperties *bool              `json:"unevaluatedProperties,omitempty" yaml:"unevaluatedProperties,omitempty"`
-	Const                 any                `json:"const,omitempty" yaml:"const,omitempty"`
+	Schema                string              `json:"$schema,omitempty" yaml:"$schema,omitempty"`
+	ID                    string              `json:"$id,omitempty" yaml:"$id,omitempty"`
+	Vocabulary            map[string]bool     `json:"$vocabulary,omitempty" yaml:"$vocabulary,omitempty"`
+	Anchor                string              `json:"$anchor,omitempty" yaml:"$anchor,omitempty"`
+	DynamicAnchor         string              `json:"$dynamicAnchor,omitempty" yaml:"$dynamicAnchor,omitempty"`
+	RecursiveAnchor       string              `json:"$recursiveAnchor,omitempty" yaml:"$recursiveAnchor,omitempty"` // Deprecated. Replaced by $dynamicAnchor
+	Title                 string              `json:"title,omitempty" yaml:"title,omitempty"`
+	Description           string              `json:"description,omitempty" yaml:"description,omitempty"`
+	Comment               string              `json:"$comment,omitempty" yaml:"$comment,omitempty"`
+	Examples              []any               `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Deprecated            bool                `json:"decrecated,omitempty" yaml:"deprecated,omitempty"`
+	ReadOnly              bool                `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
+	WriteOnly             bool                `json:"writeOnly,omitempty" yaml:"writeOnly,omitempty"`
+	Default               any                 `json:"default,omitempty" yaml:"default,omitempty"`
+	Ref                   string              `json:"$ref,omitempty" yaml:"$ref,omitempty"`
+	RefReferrer           Referrer            `json:"-" yaml:"-"`
+	DynamicRef            string              `json:"$dynamicRef,omitempty" yaml:"$dynamicRef,omitempty"`
+	DynamicRefReferrer    Referrer            `json:"-" yaml:"-"`
+	RecursiveRef          string              `json:"$recursiveRef,omitempty" yaml:"$recursiveRef,omitempty"` // Deprecated. Replaced by $dynamicRef
+	Type                  any                 `json:"type,omitempty" yaml:"type,omitempty"`
+	Const                 any                 `json:"const,omitempty" yaml:"const,omitempty"`
+	Enum                  []any               `json:"enum,omitempty" yaml:"enum,omitempty"`
+	AllOf                 []*Schema           `json:"allOf,omitempty" yaml:"allOf,omitempty"`
+	AnyOf                 []*Schema           `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`
+	OneOf                 []*Schema           `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
+	Not                   *Schema             `json:"not,omitempty" yaml:"not,omitempty"`
+	If                    *Schema             `json:"if,omitempty" yaml:"if,omitempty"`
+	Then                  *Schema             `json:"then,omitempty" yaml:"then,omitempty"`
+	Else                  *Schema             `json:"else,omitempty" yaml:"else,omitempty"`
+	ExclusiveMaximum      *float64            `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+	Maximum               *float64            `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	ExclusiveMinimum      *float64            `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+	Minimum               *float64            `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	MultipleOf            *float64            `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+	Pattern               string              `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+	Format                string              `json:"format,omitempty" yaml:"format,omitempty"`
+	MaxLength             *uint64             `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+	MinLength             *uint64             `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+	ContentEncoding       string              `json:"contentEncoding,omitempty" yaml:"contentEncoding,omitempty"`
+	ContentMediaType      string              `json:"contentMediaType,omitempty" yaml:"contentMediaType,omitempty"`
+	ContentSchema         *Schema             `json:"contentSchema,omitempty" yaml:"contentSchema,omitempty"`
+	MaxItems              *uint64             `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+	MinItems              *uint64             `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+	UniqueItems           bool                `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+	MaxContains           *uint64             `json:"maxContains,omitempty" yaml:"maxContains,omitempty"`
+	MinContains           *uint64             `json:"minContains,omitempty" yaml:"minContains,omitempty"`
+	Contains              *Schema             `json:"contains,omitempty" yaml:"contains,omitempty"`
+	PrefixItems           []*Schema           `json:"prefixItems,omitempty" yaml:"prefixItems,omitempty"`
+	Items                 *Schema             `json:"items,omitempty" yaml:"items,omitempty"`
+	AdditionalItems       *Schema             `json:"additionalItems,omitempty" yaml:"additionalItems,omitempty"`
+	UnevaluatedItems      *Schema             `json:"unevaluatedItems,omitempty" yaml:"unevaluatedItems,omitempty"`
+	Required              []string            `json:"required,omitempty" yaml:"required,omitempty"`
+	MaxProperties         *uint64             `json:"maxProperties,omitempty" yaml:"maxProperties,omitempty"`
+	MinProperties         *uint64             `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
+	PropertyNames         *Schema             `json:"propertyNames,omitempty" yaml:"propertyNames,omitempty"`
+	Properties            map[string]*Schema  `json:"properties,omitempty" yaml:"properties,omitempty"`
+	PatternProperties     map[string]*Schema  `json:"patternProperties,omitempty" yaml:"patternProperties,omitempty"`
+	AdditionalProperties  *Schema             `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
+	UnevaluatedProperties *Schema             `json:"unevaluatedProperties,omitempty" yaml:"unevaluatedProperties,omitempty"`
+	DependentRequired     map[string][]string `json:"dependentRequired,omitempty" yaml:"dependentRequired,omitempty"`
+	Dependencies          any                 `json:"dependencies,omitempty" yaml:"dependencies,omitempty"` // Deprecated. Replaced by "dependentSchemas" and "dependentRequired"
+	DependentSchemas      map[string]*Schema  `json:"dependentSchemas,omitempty" yaml:"dependentSchemas,omitempty"`
 
 	Defs map[string]*Schema `json:"$defs,omitempty" yaml:"$defs,omitempty"`
 	// Deprecated: This field was renamed to "$defs" in draft 2019-09,
@@ -134,40 +161,66 @@ func (s *Schema) IsZero() bool {
 	case s.kind != 0,
 		len(s.Schema) > 0,
 		len(s.ID) > 0,
+		len(s.Vocabulary) > 0,
+		len(s.Anchor) > 0,
+		len(s.DynamicAnchor) > 0,
+		len(s.RecursiveAnchor) > 0,
 		len(s.Title) > 0,
 		len(s.Description) > 0,
 		len(s.Comment) > 0,
 		len(s.Examples) > 0,
+		s.Deprecated,
 		s.ReadOnly,
+		s.WriteOnly,
 		s.Default != nil,
 		len(s.Ref) > 0,
+		len(s.DynamicRef) > 0,
+		len(s.RecursiveRef) > 0,
 		s.Type != nil,
+		s.Const != nil,
 		len(s.Enum) > 0,
 		len(s.AllOf) > 0,
 		len(s.AnyOf) > 0,
 		len(s.OneOf) > 0,
 		s.Not != nil,
+		s.If != nil,
+		s.Then != nil,
+		s.Else != nil,
+		s.ExclusiveMaximum != nil,
 		s.Maximum != nil,
+		s.ExclusiveMinimum != nil,
 		s.Minimum != nil,
 		s.MultipleOf != nil,
 		len(s.Pattern) > 0,
+		len(s.Format) > 0,
 		s.MaxLength != nil,
 		s.MinLength != nil,
+		len(s.ContentEncoding) > 0,
+		len(s.ContentMediaType) > 0,
+		s.ContentSchema != nil,
 		s.MaxItems != nil,
 		s.MinItems != nil,
 		s.UniqueItems,
+		s.MaxContains != nil,
+		s.MinContains != nil,
+		s.Contains != nil,
+		len(s.PrefixItems) > 0,
 		s.Items != nil,
 		s.AdditionalItems != nil,
+		s.UnevaluatedItems != nil,
 		len(s.Required) > 0,
 		s.MaxProperties != nil,
 		s.MinProperties != nil,
+		s.PropertyNames != nil,
 		len(s.Properties) > 0,
 		len(s.PatternProperties) > 0,
 		s.AdditionalProperties != nil,
 		s.UnevaluatedProperties != nil,
 		len(s.Defs) > 0,
 		len(s.Definitions) > 0,
-		s.Const != nil:
+		len(s.DependentRequired) > 0,
+		s.Dependencies != nil,
+		len(s.DependentSchemas) > 0:
 		return false
 	default:
 		return true
@@ -402,41 +455,6 @@ func parseNode(ptr Ptr, keyNode, valNode *yaml.Node, useHelmDocs bool) (*Schema,
 
 func (schema *Schema) Subschemas() iter.Seq2[Ptr, *Schema] {
 	return func(yield func(Ptr, *Schema) bool) {
-		for key, subSchema := range iterMapOrdered(schema.Properties) {
-			if subSchema.Kind() == SchemaKindObject && !yield(NewPtr("properties", key), subSchema) {
-				return
-			}
-		}
-		if schema.AdditionalProperties != nil && schema.AdditionalProperties.Kind() == SchemaKindObject {
-			if !yield(NewPtr("additionalProperties"), schema.AdditionalProperties) {
-				return
-			}
-		}
-		for key, subSchema := range iterMapOrdered(schema.PatternProperties) {
-			if subSchema.Kind() == SchemaKindObject && !yield(NewPtr("patternProperties", key), subSchema) {
-				return
-			}
-		}
-		if schema.Items != nil && schema.Items.Kind() == SchemaKindObject {
-			if !yield(NewPtr("items"), schema.Items) {
-				return
-			}
-		}
-		if schema.AdditionalItems != nil && schema.AdditionalItems.Kind() == SchemaKindObject {
-			if !yield(NewPtr("additionalItems"), schema.AdditionalItems) {
-				return
-			}
-		}
-		for key, subSchema := range iterMapOrdered(schema.Defs) {
-			if subSchema.Kind() == SchemaKindObject && !yield(NewPtr("$defs", key), subSchema) {
-				return
-			}
-		}
-		for key, subSchema := range iterMapOrdered(schema.Definitions) {
-			if subSchema.Kind() == SchemaKindObject && !yield(NewPtr("definitions", key), subSchema) {
-				return
-			}
-		}
 		for index, subSchema := range schema.AllOf {
 			if subSchema.Kind() == SchemaKindObject && !yield(NewPtr("allOf").Item(index), subSchema) {
 				return
@@ -454,6 +472,91 @@ func (schema *Schema) Subschemas() iter.Seq2[Ptr, *Schema] {
 		}
 		if schema.Not != nil {
 			if schema.Not.Kind() == SchemaKindObject && !yield(NewPtr("not"), schema.Not) {
+				return
+			}
+		}
+		if schema.If != nil {
+			if schema.If.Kind() == SchemaKindObject && !yield(NewPtr("if"), schema.If) {
+				return
+			}
+		}
+		if schema.Then != nil {
+			if schema.Then.Kind() == SchemaKindObject && !yield(NewPtr("then"), schema.Then) {
+				return
+			}
+		}
+		if schema.Else != nil {
+			if schema.Else.Kind() == SchemaKindObject && !yield(NewPtr("else"), schema.Else) {
+				return
+			}
+		}
+		if schema.ContentSchema != nil {
+			if schema.ContentSchema.Kind() == SchemaKindObject && !yield(NewPtr("contentSchema"), schema.ContentSchema) {
+				return
+			}
+		}
+		if schema.Contains != nil {
+			if schema.Contains.Kind() == SchemaKindObject && !yield(NewPtr("contains"), schema.Contains) {
+				return
+			}
+		}
+		for index, subSchema := range schema.PrefixItems {
+			if subSchema.Kind() == SchemaKindObject && !yield(NewPtr("prefixItems").Item(index), subSchema) {
+				return
+			}
+		}
+		if schema.Items != nil {
+			if schema.Items.Kind() == SchemaKindObject && !yield(NewPtr("items"), schema.Items) {
+				return
+			}
+		}
+		if schema.AdditionalItems != nil {
+			if schema.AdditionalItems.Kind() == SchemaKindObject && !yield(NewPtr("additionalItems"), schema.AdditionalItems) {
+				return
+			}
+		}
+		if schema.UnevaluatedItems != nil {
+			if schema.UnevaluatedItems.Kind() == SchemaKindObject && !yield(NewPtr("unevaluatedItems"), schema.UnevaluatedItems) {
+				return
+			}
+		}
+		if schema.PropertyNames != nil {
+			if schema.PropertyNames.Kind() == SchemaKindObject && !yield(NewPtr("propertyNames"), schema.PropertyNames) {
+				return
+			}
+		}
+		for key, subSchema := range iterMapOrdered(schema.Properties) {
+			if subSchema.Kind() == SchemaKindObject && !yield(NewPtr("properties", key), subSchema) {
+				return
+			}
+		}
+		for key, subSchema := range iterMapOrdered(schema.PatternProperties) {
+			if subSchema.Kind() == SchemaKindObject && !yield(NewPtr("patternProperties", key), subSchema) {
+				return
+			}
+		}
+		if schema.AdditionalProperties != nil {
+			if schema.AdditionalProperties.Kind() == SchemaKindObject && !yield(NewPtr("additionalProperties"), schema.AdditionalProperties) {
+				return
+			}
+		}
+		if schema.UnevaluatedProperties != nil {
+			if schema.UnevaluatedProperties.Kind() == SchemaKindObject && !yield(NewPtr("unevaluatedProperties"), schema.UnevaluatedProperties) {
+				return
+			}
+		}
+		for key, subSchema := range iterMapOrdered(schema.DependentSchemas) {
+			if subSchema.Kind() == SchemaKindObject && !yield(NewPtr("dependentSchemas", key), subSchema) {
+				return
+			}
+		}
+		for key, subSchema := range iterMapOrdered(schema.Defs) {
+			if subSchema.Kind() == SchemaKindObject && !yield(NewPtr("$defs", key), subSchema) {
+				return
+			}
+		}
+		for key, subSchema := range iterMapOrdered(schema.Definitions) {
+			if subSchema.Kind() == SchemaKindObject && !yield(NewPtr("definitions", key), subSchema) {
 				return
 			}
 		}
@@ -491,6 +594,9 @@ func (s *Schema) SetReferrer(ref Referrer) {
 	}
 	if s.Ref != "" {
 		s.RefReferrer = ref
+	}
+	if s.DynamicRef != "" {
+		s.DynamicRefReferrer = ref
 	}
 }
 

--- a/pkg/schema_test.go
+++ b/pkg/schema_test.go
@@ -104,40 +104,65 @@ func TestSchemaIsZero(t *testing.T) {
 		{name: "Kind", schema: &Schema{kind: SchemaKindTrue}},
 		{name: "Schema", schema: &Schema{Schema: exampleString}},
 		{name: "ID", schema: &Schema{ID: exampleString}},
+		{name: "Vocabulary", schema: &Schema{Vocabulary: map[string]bool{exampleString: exampleBool}}},
+		{name: "Anchor", schema: &Schema{Anchor: exampleString}},
+		{name: "DynamicAnchor", schema: &Schema{DynamicAnchor: exampleString}},
+		{name: "RecursiveAnchor", schema: &Schema{RecursiveAnchor: exampleString}},
 		{name: "Title", schema: &Schema{Title: exampleString}},
 		{name: "Description", schema: &Schema{Description: exampleString}},
 		{name: "Comment", schema: &Schema{Comment: exampleString}},
 		{name: "Examples", schema: &Schema{Examples: exampleAnySlice}},
+		{name: "Deprecated", schema: &Schema{Deprecated: exampleBool}},
 		{name: "ReadOnly", schema: &Schema{ReadOnly: exampleBool}},
+		{name: "WriteOnly", schema: &Schema{WriteOnly: exampleBool}},
 		{name: "Default", schema: &Schema{Default: exampleString}},
 		{name: "Ref", schema: &Schema{Ref: exampleString}},
+		{name: "DynamicRef", schema: &Schema{DynamicRef: exampleString}},
+		{name: "RecursiveRef", schema: &Schema{RecursiveRef: exampleString}},
 		{name: "Type", schema: &Schema{Type: exampleString}},
+		{name: "Const", schema: &Schema{Const: exampleString}},
 		{name: "Enum", schema: &Schema{Enum: exampleAnySlice}},
 		{name: "AllOf", schema: &Schema{AllOf: exampleSchemaSlice}},
 		{name: "AnyOf", schema: &Schema{AnyOf: exampleSchemaSlice}},
 		{name: "OneOf", schema: &Schema{OneOf: exampleSchemaSlice}},
 		{name: "Not", schema: &Schema{Not: &Schema{ID: exampleString}}},
+		{name: "If", schema: &Schema{If: exampleSchema}},
+		{name: "Then", schema: &Schema{Then: exampleSchema}},
+		{name: "Else", schema: &Schema{Else: exampleSchema}},
+		{name: "ExclusiveMaximum", schema: &Schema{ExclusiveMaximum: &exampleFloat64}},
 		{name: "Maximum", schema: &Schema{Maximum: &exampleFloat64}},
+		{name: "ExclusiveMinimum", schema: &Schema{ExclusiveMinimum: &exampleFloat64}},
 		{name: "Minimum", schema: &Schema{Minimum: &exampleFloat64}},
 		{name: "MultipleOf", schema: &Schema{MultipleOf: &exampleFloat64}},
 		{name: "Pattern", schema: &Schema{Pattern: exampleString}},
+		{name: "Format", schema: &Schema{Format: exampleString}},
 		{name: "MaxLength", schema: &Schema{MaxLength: &exampleUint64}},
 		{name: "MinLength", schema: &Schema{MinLength: &exampleUint64}},
+		{name: "ContentEncoding", schema: &Schema{ContentEncoding: exampleString}},
+		{name: "ContentMediaType", schema: &Schema{ContentMediaType: exampleString}},
+		{name: "ContentSchema", schema: &Schema{ContentSchema: exampleSchema}},
 		{name: "MaxItems", schema: &Schema{MaxItems: &exampleUint64}},
 		{name: "MinItems", schema: &Schema{MinItems: &exampleUint64}},
 		{name: "UniqueItems", schema: &Schema{UniqueItems: exampleBool}},
+		{name: "MaxContains", schema: &Schema{MaxContains: &exampleUint64}},
+		{name: "MinContains", schema: &Schema{MinContains: &exampleUint64}},
+		{name: "Contains", schema: &Schema{Contains: exampleSchema}},
+		{name: "PrefixItems", schema: &Schema{PrefixItems: exampleSchemaSlice}},
 		{name: "Items", schema: &Schema{Items: &Schema{ID: exampleString}}},
 		{name: "AdditionalItems", schema: &Schema{AdditionalItems: &Schema{ID: exampleString}}},
 		{name: "Required", schema: &Schema{Required: []string{exampleString}}},
 		{name: "MaxProperties", schema: &Schema{MaxProperties: &exampleUint64}},
 		{name: "MinProperties", schema: &Schema{MinProperties: &exampleUint64}},
+		{name: "UnevaluatedItems", schema: &Schema{UnevaluatedItems: exampleSchema}},
 		{name: "Properties", schema: &Schema{Properties: exampleMap}},
 		{name: "PatternProperties", schema: &Schema{PatternProperties: exampleMap}},
 		{name: "AdditionalProperties", schema: &Schema{AdditionalProperties: exampleSchema}},
-		{name: "UnevaluatedProperties", schema: &Schema{UnevaluatedProperties: &exampleBool}},
+		{name: "UnevaluatedProperties", schema: &Schema{UnevaluatedProperties: exampleSchema}},
+		{name: "DependentRequired", schema: &Schema{DependentRequired: map[string][]string{exampleString: {exampleString}}}},
+		{name: "Dependencies", schema: &Schema{Dependencies: exampleAnySlice}},
+		{name: "DependentSchemas", schema: &Schema{DependentSchemas: exampleMap}},
 		{name: "Defs", schema: &Schema{Defs: exampleMap}},
 		{name: "Definitions", schema: &Schema{Definitions: exampleMap}},
-		{name: "Const", schema: &Schema{Const: exampleString}},
 	}
 
 	for _, tt := range tests {
@@ -717,15 +742,29 @@ func TestSchemaSubschemas_order(t *testing.T) {
 		{
 			name: "items",
 			schema: &Schema{
-				Properties: map[string]*Schema{"a": {ID: "a"}, "b": {ID: "b"}},
-				Items:      &Schema{ID: "c"},
+				Items:      &Schema{ID: "a"},
+				Properties: map[string]*Schema{"b": {ID: "b"}, "c": {ID: "c"}},
+			},
+		},
+		{
+			name: "unevaluatedItems",
+			schema: &Schema{
+				AllOf:            []*Schema{{ID: "a"}, {ID: "b"}},
+				UnevaluatedItems: &Schema{ID: "c"},
 			},
 		},
 		{
 			name: "additionalItems",
 			schema: &Schema{
-				Properties:      map[string]*Schema{"a": {ID: "a"}, "b": {ID: "b"}},
+				AllOf:           []*Schema{{ID: "a"}, {ID: "b"}},
 				AdditionalItems: &Schema{ID: "c"},
+			},
+		},
+		{
+			name: "propertyNames",
+			schema: &Schema{
+				AllOf:         []*Schema{{ID: "a"}, {ID: "b"}},
+				PropertyNames: &Schema{ID: "c"},
 			},
 		},
 		{
@@ -739,6 +778,19 @@ func TestSchemaSubschemas_order(t *testing.T) {
 			schema: &Schema{
 				Properties:           map[string]*Schema{"a": {ID: "a"}, "b": {ID: "b"}},
 				AdditionalProperties: &Schema{ID: "c"},
+			},
+		},
+		{
+			name: "unevaluatedProperties",
+			schema: &Schema{
+				Properties:            map[string]*Schema{"a": {ID: "a"}, "b": {ID: "b"}},
+				UnevaluatedProperties: &Schema{ID: "c"},
+			},
+		},
+		{
+			name: "dependentSchemas",
+			schema: &Schema{
+				DependentSchemas: map[string]*Schema{"a": {ID: "a"}, "b": {ID: "b"}, "c": {ID: "c"}},
 			},
 		},
 		{
@@ -784,6 +836,49 @@ func TestSchemaSubschemas_order(t *testing.T) {
 				Not:   &Schema{ID: "c"},
 			},
 		},
+		{
+			name: "if",
+			schema: &Schema{
+				AllOf: []*Schema{{ID: "a"}, {ID: "b"}},
+				If:    &Schema{ID: "c"},
+			},
+		},
+		{
+			name: "if-then",
+			schema: &Schema{
+				AllOf: []*Schema{{ID: "a"}},
+				If:    &Schema{ID: "b"},
+				Then:  &Schema{ID: "c"},
+			},
+		},
+		{
+			name: "if-then-else",
+			schema: &Schema{
+				If:   &Schema{ID: "a"},
+				Then: &Schema{ID: "b"},
+				Else: &Schema{ID: "c"},
+			},
+		},
+		{
+			name: "contentSchema",
+			schema: &Schema{
+				AllOf:         []*Schema{{ID: "a"}, {ID: "b"}},
+				ContentSchema: &Schema{ID: "c"},
+			},
+		},
+		{
+			name: "contains",
+			schema: &Schema{
+				AllOf:    []*Schema{{ID: "a"}, {ID: "b"}},
+				Contains: &Schema{ID: "c"},
+			},
+		},
+		{
+			name: "prefixItems",
+			schema: &Schema{
+				PrefixItems: []*Schema{{ID: "a"}, {ID: "b"}, {ID: "c"}},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -797,7 +892,7 @@ func TestSchemaSubschemas_order(t *testing.T) {
 						break
 					}
 				}
-				require.Equal(t, "abc", strings.Join(ids, ""))
+				testutil.MustEqual(t, "abc", strings.Join(ids, ""))
 			}
 		})
 	}
@@ -1043,6 +1138,36 @@ func TestSchemaSetReferrer(t *testing.T) {
 					Not: &Schema{
 						Ref:         "foo",
 						RefReferrer: ReferrerDir("referrer"),
+					},
+				},
+			},
+		},
+		{
+			name: "root dynamicRef",
+			schema: &Schema{
+				DynamicRef: "foo",
+			},
+			referrer: ReferrerDir("referrer"),
+			want: &Schema{
+				DynamicRef:         "foo",
+				DynamicRefReferrer: ReferrerDir("referrer"),
+			},
+		},
+		{
+			name: "deeply nested dynamicRef",
+			schema: &Schema{
+				Items: &Schema{
+					Not: &Schema{
+						DynamicRef: "foo",
+					},
+				},
+			},
+			referrer: ReferrerDir("referrer"),
+			want: &Schema{
+				Items: &Schema{
+					Not: &Schema{
+						DynamicRef:         "foo",
+						DynamicRefReferrer: ReferrerDir("referrer"),
 					},
 				},
 			},

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -9,19 +9,12 @@ import (
 	"slices"
 )
 
-func uniqueStringAppend(dest []string, src ...string) []string {
-	existingItems := make(map[string]bool)
-	for _, item := range dest {
-		existingItems[item] = true
-	}
-
+func uniqueStringAppend(dest, src []string) []string {
 	for _, item := range src {
-		if _, exists := existingItems[item]; !exists {
+		if !slices.Contains(dest, item) {
 			dest = append(dest, item)
-			existingItems[item] = true
 		}
 	}
-
 	return dest
 }
 

--- a/pkg/utils_test.go
+++ b/pkg/utils_test.go
@@ -74,7 +74,7 @@ func TestUniqueStringAppend(t *testing.T) {
 			copy(destCopy, tt.dest)
 
 			// Call the function with the copy.
-			got := uniqueStringAppend(destCopy, tt.src...)
+			got := uniqueStringAppend(destCopy, tt.src)
 
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("uniqueStringAppend() = %v, want %v", got, tt.want)


### PR DESCRIPTION
This does ***NOT*** add `# @schema ...` comment annotation support for all JSON Schema keywords, but it does add all JSON Schema keywords to `helm schema`'s internal data structure.

This is important when bundling schemas, as this now allows you to bundle schemas that makes use of any of these keywords:

- $vocabulary
- $anchor
- $dynamicAnchor
- $recursiveAnchor
- deprecated
- writeOnly
- $dynamicRef
- $recursiveRef
- if
- then
- else
- exclusiveMaximum
- exclusiveMinimum
- format
- contentEncoding
- contentMediaType
- contentSchema
- maxContains
- minContains
- contains
- prefixItems
- unevaluatedItems
- propertyNames
- dependentRequired
- dependencies
- dependentSchemas

Closes #263
