### PR TITLE
chore: Fix auto-approve workflow

### DIFF
--- a/.github/workflows/auto-approve-dependabot.yml
+++ b/.github/workflows/auto-approve-dependabot.yml
@@ -7,7 +7,7 @@ permissions:
   pull-requests: write
 
 # Based on officially documented implementation
-# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#approve-a-pull-request
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enabling-automerge-on-a-pull-request
 jobs:
   dependabot-auto-approve:
     runs-on: ubuntu-latest
@@ -17,9 +17,7 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2
         with:
-          github-token: '${{ github.token }}'
-          # Dependabot doesn't use commit signing on our GitHub Enterprise.
-          skip-commit-verification: true
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: Approve PR and enable auto-merge
         if: |
@@ -30,4 +28,4 @@ jobs:
           gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Tries to fix the workflow.

I don't think these changes are actually why it failed. But it doesn't hurt to remove my GitHub Enterprise stuff and to use `secrets.GITHUB_TOKEN` as advised by the [docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enabling-automerge-on-a-pull-request) instead of `github.token` (should be the same though...)
