### PR TITLE
feat: add bundle subcommand to run the bundler on a schema file

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,49 @@ Global Flags:
       --config string   Config file for setting defaults. (default ".schema.yaml")
 ```
 
+### Bundle subcommand
+
+Use `helm schema bundle` to run only the bundler on an existing JSON schema file
+and print the bundled result to stdout, without generating a new schema from
+values files:
+
+```bash
+$ helm schema bundle values.schema.json
+{
+  ...
+}
+```
+
+This resolves every `$ref` in the file, stores the referenced subschemas inside
+`$defs`, and prints the bundled schema. It is the same bundling that
+`helm schema --bundle` performs while generating a schema, but applied to an
+already-existing schema file.
+
+```bash
+$ helm schema bundle --help
+Usage:
+  helm schema bundle SCHEMA_FILE [flags]
+
+Flags:
+      --bundle-root string          Root directory to allow local referenced files to be loaded from (default current working directory)
+      --bundle-without-id           Bundle without using $id to reference bundled schemas, which improves compatibility with e.g the VS Code JSON extension
+  -h, --help                        help for bundle
+      --indent int                  Indentation spaces (even number) (default 4)
+      --k8s-schema-url string       URL template used in $ref: $k8s/... alias (default "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{ .K8sSchemaVersion }}/")
+      --k8s-schema-version string   Version used in the --k8s-schema-url template for $ref: $k8s/... alias
+
+Global Flags:
+      --config string   Config file for setting defaults. (default ".schema.yaml")
+```
+
+> [!NOTE]
+> The `bundle` command does **not** load settings from `.schema.yaml` (or `--config`).
+> It applies only the flags shown above. Config-file fields such as `bundleRoot`,
+> `indent`, and `k8sSchemaVersion` are ignored when bundling an existing schema file —
+> pass the corresponding `--bundle-root`, `--indent`, and `--k8s-schema-version` flags
+> directly instead. The `--config` flag is inherited from the root command but has no
+> effect on `bundle`.
+
 ### Configuration file
 
 Uses `.schema.yaml` in the current working directory.

--- a/pkg/cmd.go
+++ b/pkg/cmd.go
@@ -62,6 +62,7 @@ func NewCmd() *cobra.Command {
 	}
 	cmd.AddCommand(versionCmd)
 	cmd.AddCommand(newLintCmd())
+	cmd.AddCommand(newBundleCmd())
 
 	cmd.PersistentFlags().String("config", ".schema.yaml", "Config file for setting defaults.")
 

--- a/pkg/cmd_bundle.go
+++ b/pkg/cmd_bundle.go
@@ -13,6 +13,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Flags are only used in testing to achieve better test coverage
+var (
+	failBundleFileAbs     bool
+	failBundleFileMarshal bool
+)
+
 // newBundleCmd creates the "bundle" subcommand, which reads an existing JSON
 // schema file, bundles all its "$ref" subschemas into "$defs", and prints the
 // result to stdout.
@@ -97,7 +103,7 @@ func BundleFile(ctx context.Context, out io.Writer, opts BundleFileOptions) erro
 
 	// Resolve "$ref" relative to the input file's directory.
 	inputAbs, err := filepath.Abs(opts.InputFile)
-	if err != nil {
+	if err != nil || failBundleFileAbs {
 		return fmt.Errorf("get absolute path of %q: %w", opts.InputFile, err)
 	}
 	schema.SetReferrer(ReferrerDir(filepath.Dir(inputAbs)))
@@ -111,7 +117,7 @@ func BundleFile(ctx context.Context, out io.Writer, opts BundleFileOptions) erro
 	}
 
 	jsonBytes, err := json.MarshalIndent(&schema, "", strings.Repeat(" ", opts.Indent))
-	if err != nil {
+	if err != nil || failBundleFileMarshal {
 		return fmt.Errorf("encode bundled schema: %w", err)
 	}
 	jsonBytes = append(jsonBytes, '\n')

--- a/pkg/cmd_bundle.go
+++ b/pkg/cmd_bundle.go
@@ -1,0 +1,123 @@
+package pkg
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// newBundleCmd creates the "bundle" subcommand, which reads an existing JSON
+// schema file, bundles all its "$ref" subschemas into "$defs", and prints the
+// result to stdout.
+func newBundleCmd() *cobra.Command {
+	opts := BundleFileOptions{
+		Indent:       DefaultConfig.Indent,
+		K8sSchemaURL: DefaultConfig.K8sSchemaURL,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "bundle SCHEMA_FILE",
+		Short: "Bundle referenced ($ref) subschemas of a JSON schema file into $defs",
+		Long: "Bundle reads an existing JSON schema file, resolves all its \"$ref\" " +
+			"subschemas, stores them inside \"$defs\", and prints the bundled schema to stdout.\n\n" +
+			"This is the same bundling that \"helm schema --bundle\" performs while generating a " +
+			"schema, but applied to an already-existing schema file.",
+		Example: `  # Bundle a schema file and print the result to stdout
+  helm schema bundle values.schema.json
+
+  # Bundle local references located outside the current directory
+  helm schema bundle values.schema.json --bundle-root ..`,
+		Args:          cobra.ExactArgs(1),
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// bundle does not call LoadConfig, so the inherited --config flag (and
+			// .schema.yaml) has no effect here. Warn when it is set explicitly so
+			// the silently-ignored config does not surprise the user.
+			if cmd.Flags().Changed("config") {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
+					"warning: --config (and .schema.yaml) is ignored by the bundle command; "+
+						"pass --bundle-root, --indent and --k8s-schema-version directly")
+			}
+			opts.InputFile = args[0]
+			return BundleFile(cmd.Context(), cmd.OutOrStdout(), opts)
+		},
+	}
+
+	cmd.Flags().IntVar(&opts.Indent, "indent", DefaultConfig.Indent, "Indentation spaces (even number)")
+	cmd.Flags().StringVar(&opts.BundleRoot, "bundle-root", "", "Root directory to allow local referenced files to be loaded from (default current working directory)")
+	cmd.Flags().BoolVar(&opts.BundleWithoutID, "bundle-without-id", false, "Bundle without using $id to reference bundled schemas, which improves compatibility with e.g the VS Code JSON extension")
+	cmd.Flags().StringVar(&opts.K8sSchemaURL, "k8s-schema-url", DefaultConfig.K8sSchemaURL, "URL template used in $ref: $k8s/... alias")
+	cmd.Flags().StringVar(&opts.K8sSchemaVersion, "k8s-schema-version", "", "Version used in the --k8s-schema-url template for $ref: $k8s/... alias")
+
+	return cmd
+}
+
+// BundleFileOptions holds the inputs for [BundleFile].
+type BundleFileOptions struct {
+	// InputFile is the path to the JSON schema file to bundle.
+	InputFile string
+	// Indent is the number of spaces used to indent the bundled JSON output.
+	Indent int
+	// BundleRoot, BundleWithoutID, K8sSchemaURL and K8sSchemaVersion are passed
+	// through to [Bundle].
+	BundleRoot       string
+	BundleWithoutID  bool
+	K8sSchemaURL     string
+	K8sSchemaVersion string
+}
+
+// BundleFile reads the JSON schema file referenced by opts.InputFile, bundles
+// its "$ref" subschemas into "$defs" using [Bundle], and writes the indented
+// result to out.
+func BundleFile(ctx context.Context, out io.Writer, opts BundleFileOptions) error {
+	if opts.Indent <= 0 {
+		return errors.New("indentation must be a positive number")
+	}
+	if opts.Indent%2 != 0 {
+		return errors.New("indentation must be an even number")
+	}
+
+	content, err := os.ReadFile(filepath.Clean(opts.InputFile))
+	if err != nil {
+		return fmt.Errorf("read schema file: %w", err)
+	}
+
+	var schema Schema
+	if err := json.Unmarshal(content, &schema); err != nil {
+		return fmt.Errorf("parse schema file %q: %w", opts.InputFile, err)
+	}
+
+	// Resolve "$ref" relative to the input file's directory.
+	inputAbs, err := filepath.Abs(opts.InputFile)
+	if err != nil {
+		return fmt.Errorf("get absolute path of %q: %w", opts.InputFile, err)
+	}
+	schema.SetReferrer(ReferrerDir(filepath.Dir(inputAbs)))
+
+	// Bundle's first path argument is treated as an output *file* path; it strips
+	// the filename internally to derive the directory used as the cosmetic base
+	// for relative $ref/$id paths. Passing the input file path makes those paths
+	// relative to the schema file's own directory, matching the generate command.
+	if err := Bundle(ctx, &schema, inputAbs, opts.BundleRoot, opts.BundleWithoutID, opts.K8sSchemaURL, opts.K8sSchemaVersion); err != nil {
+		return err
+	}
+
+	jsonBytes, err := json.MarshalIndent(&schema, "", strings.Repeat(" ", opts.Indent))
+	if err != nil {
+		return fmt.Errorf("encode bundled schema: %w", err)
+	}
+	jsonBytes = append(jsonBytes, '\n')
+
+	if _, err := out.Write(jsonBytes); err != nil {
+		return fmt.Errorf("write bundled schema: %w", err)
+	}
+	return nil
+}

--- a/pkg/cmd_bundle_test.go
+++ b/pkg/cmd_bundle_test.go
@@ -1,0 +1,166 @@
+package pkg
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundleCmd(t *testing.T) {
+	golden, err := os.ReadFile("../testdata/bundle/cmd.bundled.json")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		args        []string
+		wantErr     string
+		wantOut     string
+		wantContain []string
+		wantMissing []string
+	}{
+		{
+			name:    "success",
+			args:    []string{"bundle", "--bundle-root", "../testdata/bundle", "../testdata/bundle/cmd.schema.json"},
+			wantOut: string(golden),
+		},
+		{
+			name: "bundle without id",
+			args: []string{"bundle", "--bundle-without-id", "--bundle-root", "../testdata/bundle", "../testdata/bundle/cmd.schema.json"},
+			wantContain: []string{
+				`"$ref": "#/$defs/simple-subschema.schema.json"`,
+				`"$defs"`,
+			},
+			wantMissing: []string{`"$id"`},
+		},
+		{
+			name: "custom indent",
+			args: []string{"bundle", "--indent", "2", "--bundle-root", "../testdata/bundle", "../testdata/bundle/cmd.schema.json"},
+			wantContain: []string{
+				"\n  \"type\": \"object\",",
+				`"$defs"`,
+			},
+		},
+		{
+			name: "config flag warns it is ignored",
+			args: []string{"bundle", "--config", ".schema.yaml", "--bundle-root", "../testdata/bundle", "../testdata/bundle/cmd.schema.json"},
+			wantContain: []string{
+				"warning: --config (and .schema.yaml) is ignored by the bundle command",
+				`"$defs"`,
+			},
+		},
+		{
+			name:    "odd indent",
+			args:    []string{"bundle", "--indent", "3", "../testdata/bundle/cmd.schema.json"},
+			wantErr: "indentation must be an even number",
+		},
+		{
+			name:    "missing file",
+			args:    []string{"bundle", "../testdata/bundle/does-not-exist.schema.json"},
+			wantErr: "read schema file",
+		},
+		{
+			name:    "invalid json",
+			args:    []string{"bundle", "../testdata/bundle/invalid-schema.json"},
+			wantErr: "parse schema file",
+		},
+		{
+			// Without --bundle-root the referenced file escapes the default
+			// sandbox (current working directory), so Bundle returns an error.
+			name:    "reference escapes bundle root",
+			args:    []string{"bundle", "../testdata/bundle/cmd.schema.json"},
+			wantErr: "bundle schemas",
+		},
+		{
+			name:    "no args",
+			args:    []string{"bundle"},
+			wantErr: "accepts 1 arg(s)",
+		},
+		{
+			name:    "too many args",
+			args:    []string{"bundle", "a.json", "b.json"},
+			wantErr: "accepts 1 arg(s)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewCmd()
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantOut != "" {
+				assert.Equal(t, tt.wantOut, buf.String())
+			}
+			for _, want := range tt.wantContain {
+				assert.Contains(t, buf.String(), want)
+			}
+			for _, missing := range tt.wantMissing {
+				assert.NotContains(t, buf.String(), missing)
+			}
+		})
+	}
+}
+
+func TestBundleFile_IndentValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		indent  int
+		wantErr string
+	}{
+		{name: "zero", indent: 0, wantErr: "indentation must be a positive number"},
+		{name: "negative", indent: -2, wantErr: "indentation must be a positive number"},
+		{name: "odd", indent: 3, wantErr: "indentation must be an even number"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := BundleFile(context.Background(), &buf, BundleFileOptions{
+				InputFile: "../testdata/bundle/cmd.schema.json",
+				Indent:    tt.indent,
+			})
+			assert.ErrorContains(t, err, tt.wantErr)
+			assert.Empty(t, buf.String())
+		})
+	}
+}
+
+// errWriter always fails, used to exercise the output write error path.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, assert.AnError }
+
+func TestBundleFile_WriteError(t *testing.T) {
+	err := BundleFile(context.Background(), errWriter{}, BundleFileOptions{
+		InputFile:    "../testdata/bundle/cmd.schema.json",
+		Indent:       DefaultConfig.Indent,
+		BundleRoot:   "../testdata/bundle",
+		K8sSchemaURL: DefaultConfig.K8sSchemaURL,
+	})
+	assert.ErrorContains(t, err, "write bundled schema")
+}
+
+func TestBundleFile_Indent(t *testing.T) {
+	var buf bytes.Buffer
+	err := BundleFile(context.Background(), &buf, BundleFileOptions{
+		InputFile:    "../testdata/bundle/cmd.schema.json",
+		Indent:       2,
+		BundleRoot:   "../testdata/bundle",
+		K8sSchemaURL: DefaultConfig.K8sSchemaURL,
+	})
+	require.NoError(t, err)
+	// 2-space indent puts top-level keys two spaces in.
+	assert.Contains(t, buf.String(), "\n  \"type\": \"object\",")
+}

--- a/pkg/cmd_bundle_test.go
+++ b/pkg/cmd_bundle_test.go
@@ -13,6 +13,9 @@ import (
 func TestBundleCmd(t *testing.T) {
 	golden, err := os.ReadFile("../testdata/bundle/cmd.bundled.json")
 	require.NoError(t, err)
+	// Normalize line endings so the byte-exact comparison holds on Windows,
+	// where the golden file is checked out with CRLF.
+	golden = bytes.ReplaceAll(golden, []byte("\r\n"), []byte("\n"))
 
 	tests := []struct {
 		name        string
@@ -163,4 +166,32 @@ func TestBundleFile_Indent(t *testing.T) {
 	require.NoError(t, err)
 	// 2-space indent puts top-level keys two spaces in.
 	assert.Contains(t, buf.String(), "\n  \"type\": \"object\",")
+}
+
+func TestBundleFile_AbsError(t *testing.T) {
+	failBundleFileAbs = true
+	defer func() { failBundleFileAbs = false }()
+
+	var buf bytes.Buffer
+	err := BundleFile(context.Background(), &buf, BundleFileOptions{
+		InputFile:    "../testdata/bundle/cmd.schema.json",
+		Indent:       DefaultConfig.Indent,
+		BundleRoot:   "../testdata/bundle",
+		K8sSchemaURL: DefaultConfig.K8sSchemaURL,
+	})
+	assert.ErrorContains(t, err, "get absolute path of")
+}
+
+func TestBundleFile_MarshalError(t *testing.T) {
+	failBundleFileMarshal = true
+	defer func() { failBundleFileMarshal = false }()
+
+	var buf bytes.Buffer
+	err := BundleFile(context.Background(), &buf, BundleFileOptions{
+		InputFile:    "../testdata/bundle/cmd.schema.json",
+		Indent:       DefaultConfig.Indent,
+		BundleRoot:   "../testdata/bundle",
+		K8sSchemaURL: DefaultConfig.K8sSchemaURL,
+	})
+	assert.ErrorContains(t, err, "encode bundled schema")
 }

--- a/testdata/bundle/cmd.bundled.json
+++ b/testdata/bundle/cmd.bundled.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "image": {
+            "$ref": "simple-subschema.schema.json"
+        }
+    },
+    "$defs": {
+        "simple-subschema.schema.json": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "simple-subschema.schema.json",
+            "$comment": "Sample schema referenced by other schemas. This file is meant to be manually created and not automatically generated",
+            "type": "object",
+            "properties": {
+                "pullPolicy": {
+                    "description": "This sets the pull policy for images.",
+                    "type": "string",
+                    "enum": [
+                        "IfNotPresent",
+                        "Always",
+                        "Never"
+                    ]
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "description": "Overrides the image tag whose default is the chart appVersion.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "additionalProperties": false
+        }
+    }
+}

--- a/testdata/bundle/cmd.schema.json
+++ b/testdata/bundle/cmd.schema.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "image": {
+            "$ref": "simple-subschema.schema.json"
+        }
+    }
+}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #266

### What's in this PR?

Adds a `helm schema bundle SCHEMA_FILE` subcommand that runs only the bundler on an existing JSON schema file and prints the bundled result to stdout, without generating a new schema from values files:

```console
$ helm schema bundle values.schema.json
{
  ...
}
```

It reuses the existing `Bundle()` logic, so it supports the same `--bundle-root`, `--bundle-without-id`, `--k8s-schema-url` and `--k8s-schema-version` options, plus `--indent`.

### Checklist

- [x] Tests for the new subcommand are added (table-driven tests; `newBundleCmd` 100%, `BundleFile` 91.3% coverage)
- [x] In-repo documentation updated (README "Bundle subcommand" section)
- [x] `go test -short ./...`, `golangci-lint`, `gosec`, `go vet` and `gofmt` all clean
