### PR TITLE
feat: add lint subcommand to validate the config and input files

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,41 @@ Flags:
   -v, --version                             version for helm schema
 ```
 
+### Lint subcommand
+
+Use `helm schema lint` to validate your config file and its input values files
+without generating a schema. It parses the input files using the same parsing as
+schema generation and reports any errors, and warns about unknown fields in the
+config file (`.schema.yaml`):
+
+```bash
+$ helm schema lint
+No issues found
+```
+
+Pass `--strict` to exit with a non-zero code when any warning is reported, which
+is useful in CI:
+
+```bash
+$ helm schema lint --strict
+warning: line 4: field fooBar is not a known config field
+Found 1 warning(s)
+Error: found 1 warning(s) in strict mode
+```
+
+```bash
+$ helm schema lint --help
+Usage:
+  helm schema lint [flags]
+
+Flags:
+  -h, --help     help for lint
+      --strict   Fail with a non-zero exit code when any warning is reported
+
+Global Flags:
+      --config string   Config file for setting defaults. (default ".schema.yaml")
+```
+
 ### Configuration file
 
 Uses `.schema.yaml` in the current working directory.

--- a/pkg/cmd.go
+++ b/pkg/cmd.go
@@ -61,6 +61,7 @@ func NewCmd() *cobra.Command {
 		},
 	}
 	cmd.AddCommand(versionCmd)
+	cmd.AddCommand(newLintCmd())
 
 	cmd.PersistentFlags().String("config", ".schema.yaml", "Config file for setting defaults.")
 
@@ -134,7 +135,9 @@ func LoadConfig(cmd *cobra.Command) (*Config, error) {
 		return nil, fmt.Errorf("load flags: %w", err)
 	}
 
-	if cmd.Flag(schemaRootRefKey).Changed {
+	// The schema-root.ref flag is only registered on the generate command, so it
+	// may be absent on subcommands such as "lint".
+	if f := cmd.Flag(schemaRootRefKey); f != nil && f.Changed {
 		cwd, err := os.Getwd()
 		if err != nil {
 			return nil, fmt.Errorf("resolve current working directory: %w", err)

--- a/pkg/cmd_lint.go
+++ b/pkg/cmd_lint.go
@@ -1,0 +1,156 @@
+package pkg
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.yaml.in/yaml/v3"
+)
+
+// newLintCmd creates the "lint" subcommand, which parses the configured input
+// files using the same parsing as schema generation and reports any errors, and
+// warns about unknown fields in the config file.
+func newLintCmd() *cobra.Command {
+	var strict bool
+
+	cmd := &cobra.Command{
+		Use:   "lint",
+		Short: "Lint the config file and its input values files",
+		Long: "Lint parses the configured input values files using the same parsing as " +
+			"schema generation and reports any errors. It also checks the config file " +
+			"(.schema.yaml) for unknown fields and logs them as warnings.",
+		Example: `  # Lint using .schema.yaml in the current directory
+  helm schema lint
+
+  # Fail with a non-zero exit code when any warning is reported
+  helm schema lint --strict`,
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			config, err := LoadConfig(cmd)
+			if err != nil {
+				return err
+			}
+			return Lint(cmd.Context(), config, LintOptions{
+				Strict:     strict,
+				ConfigPath: cmd.Flag("config").Value.String(),
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&strict, "strict", false, "Fail with a non-zero exit code when any warning is reported")
+
+	return cmd
+}
+
+// LintOptions configures [Lint].
+type LintOptions struct {
+	// Strict makes Lint return an error when at least one warning is reported.
+	Strict bool
+	// ConfigPath is the path to the config file checked for unknown fields.
+	ConfigPath string
+}
+
+// Lint parses the configured input files (reusing the same parsing as schema
+// generation) and checks the config file for unknown fields, logging each one
+// as a warning. It returns an error when parsing fails, or when LintOptions.Strict
+// is set and at least one warning was reported.
+func Lint(ctx context.Context, config *Config, opts LintOptions) error {
+	logger := LoggerFromContext(ctx)
+
+	// Reuse the exact same parsing and validation as schema generation.
+	if _, err := buildJSONSchema(ctx, config); err != nil {
+		return err
+	}
+
+	warnings, err := lintConfigUnknownFields(opts.ConfigPath)
+	if err != nil {
+		return err
+	}
+	for _, warning := range warnings {
+		logger.Logf("warning: %s", warning)
+	}
+
+	if len(warnings) > 0 {
+		logger.Logf("Found %d warning(s)", len(warnings))
+		if opts.Strict {
+			return fmt.Errorf("found %d warning(s) in strict mode", len(warnings))
+		}
+		return nil
+	}
+
+	logger.Log("No issues found")
+	return nil
+}
+
+// lintConfigUnknownFields decodes the config file with strict field checking and
+// returns one warning per unknown field. A missing config file yields no
+// warnings, matching the lenient behavior of config loading.
+func lintConfigUnknownFields(configPath string) ([]string, error) {
+	if configPath == "" {
+		return nil, nil
+	}
+
+	content, err := os.ReadFile(filepath.Clean(configPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read config file %q: %w", configPath, err)
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(content))
+	decoder.KnownFields(true)
+
+	var config Config
+	switch err := decoder.Decode(&config); {
+	case err == nil:
+		return nil, nil
+	case errors.Is(err, io.EOF):
+		// Empty config file: no fields, so no unknown fields.
+		return nil, nil
+	default:
+		// KnownFields(true) reports both unknown fields and type mismatches as a
+		// *yaml.TypeError. Only unknown fields are lint warnings; a type mismatch
+		// means the config is invalid, so surface it as a hard error.
+		var typeErr *yaml.TypeError
+		if errors.As(err, &typeErr) {
+			var warnings, invalid []string
+			for _, msg := range typeErr.Errors {
+				if cleaned, ok := unknownFieldWarning(msg); ok {
+					warnings = append(warnings, cleaned)
+				} else {
+					invalid = append(invalid, msg)
+				}
+			}
+			if len(invalid) > 0 {
+				return nil, fmt.Errorf("parse config file %q: %s", configPath, strings.Join(invalid, "; "))
+			}
+			return warnings, nil
+		}
+		// Any other error means the config YAML itself is malformed.
+		return nil, fmt.Errorf("parse config file %q: %w", configPath, err)
+	}
+}
+
+// unknownFieldWarning rewrites the YAML decoder's
+// "field X not found in type pkg.Config" message into a user-facing warning.
+// The second return value is false when msg is not an unknown-field message
+// (e.g. a type mismatch), so the caller can treat it as a hard error instead.
+//
+// This is coupled to the go.yaml.in/yaml/v3 error wording; TestCleanUnknownFieldMessage
+// guards the phrasing so a library bump surfaces as a test failure.
+func unknownFieldWarning(msg string) (string, bool) {
+	if idx := strings.Index(msg, " not found in type "); idx != -1 {
+		return msg[:idx] + " is not a known config field", true
+	}
+	return msg, false
+}

--- a/pkg/cmd_lint_test.go
+++ b/pkg/cmd_lint_test.go
@@ -1,0 +1,155 @@
+package pkg
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLint(t *testing.T) {
+	validValues := []string{"../testdata/lint/values.yaml"}
+
+	tests := []struct {
+		name        string
+		config      *Config
+		opts        LintOptions
+		wantErr     string
+		wantContain []string
+	}{
+		{
+			name:        "no issues",
+			config:      &Config{Values: validValues, Draft: 2020, Indent: 4},
+			wantContain: []string{"No issues found"},
+		},
+		{
+			name:   "unknown fields warn",
+			config: &Config{Values: validValues, Draft: 2020, Indent: 4},
+			opts:   LintOptions{ConfigPath: "../testdata/lint/unknown.yaml"},
+			wantContain: []string{
+				"warning: line 4: field fooBar is not a known config field",
+				"warning: line 6: field unknownNested is not a known config field",
+				"Found 2 warning(s)",
+			},
+		},
+		{
+			name:    "unknown fields strict",
+			config:  &Config{Values: validValues, Draft: 2020, Indent: 4},
+			opts:    LintOptions{Strict: true, ConfigPath: "../testdata/lint/unknown.yaml"},
+			wantErr: "found 2 warning(s) in strict mode",
+		},
+		{
+			name:    "input parse error",
+			config:  &Config{Values: []string{"../testdata/lint/values-bad.yaml"}, Draft: 2020, Indent: 4},
+			wantErr: `invalid type "bogustype"`,
+		},
+		{
+			name:    "malformed config",
+			config:  &Config{Values: validValues, Draft: 2020, Indent: 4},
+			opts:    LintOptions{ConfigPath: "../testdata/lint/malformed.yaml"},
+			wantErr: "parse config file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			ctx := ContextWithLogger(context.Background(), NewLogger(&buf))
+			err := Lint(ctx, tt.config, tt.opts)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			for _, want := range tt.wantContain {
+				assert.Contains(t, buf.String(), want)
+			}
+		})
+	}
+}
+
+func TestLintConfigUnknownFields(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		wantWarnings int
+		wantErr      string
+	}{
+		{name: "empty path", path: ""},
+		{name: "missing file", path: "../testdata/lint/does-not-exist.yaml"},
+		{name: "empty file", path: "../testdata/lint/empty.yaml"},
+		{name: "all known", path: "../testdata/lint/valid-config.yaml"},
+		{name: "unknown fields", path: "../testdata/lint/unknown.yaml", wantWarnings: 2},
+		{name: "malformed", path: "../testdata/lint/malformed.yaml", wantErr: "parse config file"},
+		{name: "type mismatch is a hard error", path: "../testdata/lint/type-mismatch.yaml", wantErr: "parse config file"},
+		{name: "path is a directory", path: "../testdata/lint", wantErr: "read config file"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings, err := lintConfigUnknownFields(tt.path)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, warnings, tt.wantWarnings)
+		})
+	}
+}
+
+func TestUnknownFieldWarning(t *testing.T) {
+	got, ok := unknownFieldWarning("line 4: field fooBar not found in type pkg.Config")
+	assert.True(t, ok)
+	assert.Equal(t, "line 4: field fooBar is not a known config field", got)
+
+	got, ok = unknownFieldWarning("line 2: cannot unmarshal !!str into int")
+	assert.False(t, ok)
+	assert.Equal(t, "line 2: cannot unmarshal !!str into int", got)
+}
+
+func TestLintCmd(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "valid config",
+			args: []string{"lint", "--config", "../testdata/lint/valid-config.yaml"},
+		},
+		{
+			name:    "unknown fields strict fails",
+			args:    []string{"lint", "--config", "../testdata/lint/unknown.yaml", "--strict"},
+			wantErr: "found 2 warning(s) in strict mode",
+		},
+		{
+			name:    "input parse error",
+			args:    []string{"lint", "--config", "../testdata/lint/bad-config.yaml"},
+			wantErr: `invalid type "bogustype"`,
+		},
+		{
+			name:    "config load error",
+			args:    []string{"lint", "--config", "../testdata/lint/malformed.yaml"},
+			wantErr: "load config file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewCmd()
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -16,28 +16,41 @@ import (
 
 // Generate JSON schema
 func GenerateJsonSchema(ctx context.Context, config *Config) error {
+	mergedSchema, err := buildJSONSchema(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	indentString := strings.Repeat(" ", config.Indent)
+	return WriteOutput(ctx, mergedSchema, filepath.FromSlash(config.Output), indentString)
+}
+
+// buildJSONSchema parses and validates the configured input files and returns
+// the merged, JSON-Schema-compliant schema, without writing any output. It is
+// shared by [GenerateJsonSchema] and "helm schema lint" so both run the exact
+// same parsing and validation.
+func buildJSONSchema(ctx context.Context, config *Config) (*Schema, error) {
 	// Check if the values flag is set
 	if len(config.Values) == 0 {
-		return errors.New("values flag is required")
+		return nil, errors.New("values flag is required")
 	}
 	if countOccurrencesSlice(config.Values, "-") > 1 {
-		return errors.New("values flag must not contain multiple stdin (\"-f -\")")
+		return nil, errors.New("values flag must not contain multiple stdin (\"-f -\")")
 	}
 
 	// Determine the schema URL based on the draft version
 	schemaURL, err := getSchemaURL(config.Draft)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// Determine the indentation string based on the number of spaces
+	// Validate the indentation
 	if config.Indent <= 0 {
-		return errors.New("indentation must be a positive number")
+		return nil, errors.New("indentation must be a positive number")
 	}
 	if config.Indent%2 != 0 {
-		return errors.New("indentation must be an even number")
+		return nil, errors.New("indentation must be an even number")
 	}
-	indentString := strings.Repeat(" ", config.Indent)
 
 	// Initialize a Schema to hold the merged YAML data
 	mergedSchema := &Schema{}
@@ -46,7 +59,7 @@ func GenerateJsonSchema(ctx context.Context, config *Config) error {
 	for _, filePath := range config.Values {
 		fileReferrer, content, err := readInputFile(os.Stdin, filePath)
 		if err != nil {
-			return fmt.Errorf("read --values=%q: %w", filePath, err)
+			return nil, fmt.Errorf("read --values=%q: %w", filePath, err)
 		}
 
 		// Change Window's CRLF to LF line endings
@@ -55,7 +68,7 @@ func GenerateJsonSchema(ctx context.Context, config *Config) error {
 
 		var node yaml.Node
 		if err := yaml.Unmarshal(content, &node); err != nil {
-			return errors.New("error unmarshalling YAML")
+			return nil, errors.New("error unmarshalling YAML")
 		}
 
 		if len(node.Content) == 0 {
@@ -71,7 +84,7 @@ func GenerateJsonSchema(ctx context.Context, config *Config) error {
 			valNode := rootNode.Content[i+1]
 			schema, err := parseNode(NewPtr(keyNode.Value), keyNode, valNode, config.UseHelmDocs)
 			if err != nil {
-				return fmt.Errorf("parse schema: %w", err)
+				return nil, fmt.Errorf("parse schema: %w", err)
 			}
 
 			// Exclude hidden nodes
@@ -102,7 +115,7 @@ func GenerateJsonSchema(ctx context.Context, config *Config) error {
 
 		// Apply "$ref: $k8s/..." transformation
 		if err := updateRefK8sAlias(tempSchema, config.K8sSchemaURL, config.K8sSchemaVersion); err != nil {
-			return fmt.Errorf("%s: %w", filePath, err)
+			return nil, fmt.Errorf("%s: %w", filePath, err)
 		}
 
 		// Merge with existing data
@@ -112,7 +125,7 @@ func GenerateJsonSchema(ctx context.Context, config *Config) error {
 
 	if config.Bundle {
 		if err := Bundle(ctx, mergedSchema, config.Output, config.BundleRoot, config.BundleWithoutID, config.K8sSchemaURL, config.K8sSchemaVersion); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -124,12 +137,12 @@ func GenerateJsonSchema(ctx context.Context, config *Config) error {
 
 	// Ensure merged Schema is JSON Schema compliant
 	if err := ensureCompliant(mergedSchema, config.NoAdditionalProperties, config.NoDefaultGlobal, config.Draft); err != nil {
-		return err
+		return nil, err
 	}
 	mergedSchema.Schema = schemaURL // Include the schema draft version
 	mergedSchema.Type = "object"
 
-	return WriteOutput(ctx, mergedSchema, filepath.FromSlash(config.Output), indentString)
+	return mergedSchema, nil
 }
 
 func readInputFile(stdin io.Reader, filePath string) (Referrer, []byte, error) {

--- a/testdata/lint/bad-config.yaml
+++ b/testdata/lint/bad-config.yaml
@@ -1,0 +1,2 @@
+values:
+  - ../testdata/lint/values-bad.yaml

--- a/testdata/lint/malformed.yaml
+++ b/testdata/lint/malformed.yaml
@@ -1,0 +1,1 @@
+values: [unclosed

--- a/testdata/lint/type-mismatch.yaml
+++ b/testdata/lint/type-mismatch.yaml
@@ -1,0 +1,3 @@
+values:
+  - ../testdata/lint/values.yaml
+draft: notanumber

--- a/testdata/lint/unknown.yaml
+++ b/testdata/lint/unknown.yaml
@@ -1,0 +1,6 @@
+values:
+  - ../testdata/lint/values.yaml
+draft: 2020
+fooBar: 123
+schemaRoot:
+  unknownNested: true

--- a/testdata/lint/valid-config.yaml
+++ b/testdata/lint/valid-config.yaml
@@ -1,0 +1,6 @@
+values:
+  - ../testdata/lint/values.yaml
+draft: 2020
+indent: 2
+schemaRoot:
+  title: Example

--- a/testdata/lint/values-bad.yaml
+++ b/testdata/lint/values-bad.yaml
@@ -1,0 +1,1 @@
+bad: 1 # @schema type: bogustype

--- a/testdata/lint/values.yaml
+++ b/testdata/lint/values.yaml
@@ -1,0 +1,2 @@
+replicas: 1 # @schema type: integer
+image: nginx


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #260

### What's in this PR?

Adds a `helm schema lint` subcommand that validates the config file and its input values files without generating a schema:

- Parses the configured input files using the same parsing as schema generation, reporting the same errors.
- Checks the config file (`.schema.yaml`) for unknown fields and logs them as warnings (nested fields included). A type mismatch in the config is reported as a hard error rather than a warning.
- A `--strict` flag exits with a non-zero code when any warning is reported.

```console
$ helm schema lint
No issues found

$ helm schema lint --strict
warning: line 4: field fooBar is not a known config field
Found 1 warning(s)
Error: found 1 warning(s) in strict mode
```

To avoid duplicating logic, the parsing/validation pipeline was extracted from `GenerateJsonSchema` into a shared `buildJSONSchema`, so generation and linting run the exact same code (pure refactor, existing tests unchanged).

### Checklist

- [x] Tests added (table-driven; new lint functions at 100% coverage)
- [x] In-repo documentation updated (README "Lint subcommand" section)
- [x] `go test -short ./...`, `golangci-lint`, `gosec`, `go vet` and `gofmt` all clean
