### PR TITLE
Add --bundle-cache-min to override the minimum schema cache duration

### DIFF
--- a/.schema.yaml
+++ b/.schema.yaml
@@ -38,6 +38,12 @@ bundleRoot: "" # @schema default: ""; examples: [./, ../]
 # Flag: --bundle-without-id
 bundleWithoutID: false # @schema default: false
 
+# -- Minimum cache duration for downloaded schemas, e.g. "24h" or "30m".
+# Raises short server Cache-Control max-age values so schemas stay cached
+# longer. An empty string follows the server's caching headers.
+# Flag: --bundle-cache-min
+bundleCacheMin: "" # @schema default: ""; examples: [24h, 30m]
+
 # -- URL template used in "$ref: $k8s/..." alias.
 # Uses Go text templating, where "{{ .K8sSchemaVersion }}" maps to the k8sSchemaVersion config.
 # Flag: --k8s-schema-url

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Usage:
 
 Flags:
       --bundle                              Bundle referenced ($ref) subschemas into a single file inside $defs
+      --bundle-cache-min string             Minimum cache duration for downloaded schemas, e.g. 24h or 30m. Raises short server Cache-Control max-age values; empty follows the server
       --bundle-root string                  Root directory to allow local referenced files to be loaded from (default current working directory)
       --bundle-without-id                   Bundle without using $id to reference bundled schemas, which improves compatibility with e.g the VS Code JSON extension
       --config string                       Config file for setting defaults. (default ".schema.yaml")
@@ -206,6 +207,7 @@ Usage:
   helm schema bundle SCHEMA_FILE [flags]
 
 Flags:
+      --bundle-cache-min string     Minimum cache duration for downloaded schemas, e.g. 24h or 30m. Raises short server Cache-Control max-age values; empty follows the server
       --bundle-root string          Root directory to allow local referenced files to be loaded from (default current working directory)
       --bundle-without-id           Bundle without using $id to reference bundled schemas, which improves compatibility with e.g the VS Code JSON extension
   -h, --help                        help for bundle
@@ -244,6 +246,7 @@ output: values.schema.json
 bundle: false
 bundleRoot: ""
 bundleWithoutID: false
+bundleCacheMin: ""
 
 k8sSchemaURL: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/{{ .K8sSchemaVersion }}/
 k8sSchemaVersion: "v1.33.1"

--- a/config.schema.json
+++ b/config.schema.json
@@ -9,6 +9,15 @@
             "default": false,
             "type": "boolean"
         },
+        "bundleCacheMin": {
+            "description": "Minimum cache duration for downloaded schemas, e.g. \"24h\" or \"30m\". Raises short server Cache-Control max-age values so schemas stay cached longer. An empty string follows the server's caching headers.",
+            "examples": [
+                "24h",
+                "30m"
+            ],
+            "default": "",
+            "type": "string"
+        },
         "bundleRoot": {
             "description": "Root directory to allow local referenced files to be loaded from. Defaults to the current working directory.",
             "examples": [

--- a/docs/README.md
+++ b/docs/README.md
@@ -845,6 +845,14 @@ result in `$defs`. To enable bundling, use the command-line flags:
 - `--bundle-root /some/path` sets the root directory from which file `$ref` are
   allowed to read files from (default: current working directory)
 
+- `--bundle-cache-min 24h` raises the minimum cache duration for downloaded
+  schemas. Many schema stores return a short `Cache-Control` max-age (5 or 30
+  minutes); this overrides it so cacheable schemas stay cached for at least the
+  given duration. The value uses Go's
+  [duration syntax](https://pkg.go.dev/time#ParseDuration) (e.g. `24h`, `30m`).
+  An empty value (default) follows the server's caching headers, and responses
+  the server marks as uncacheable are still not cached.
+
 - `--bundle-without-id` works as a compatibility mode by disabling usage of
   `$id` and overriding `$ref` with syntax like `"$ref": "#/$defs/schema.json"`
   instead of retaining the original `$ref`. This is helpful for VSCode and

--- a/pkg/bundle.go
+++ b/pkg/bundle.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Bundle will use default loader settings to bundle all $ref into $defs
@@ -19,7 +20,7 @@ import (
 //
 // The paths, outputDir & bundleRoot, are only used to change absolute paths
 // into relative paths in a solely cosmetic way.
-func Bundle(ctx context.Context, schema *Schema, outputDir, bundleRoot string, withoutIDs bool, k8sSchemaURL, k8sSchemaVersion string) error {
+func Bundle(ctx context.Context, schema *Schema, outputDir, bundleRoot string, withoutIDs bool, k8sSchemaURL, k8sSchemaVersion string, cacheMinDuration time.Duration) error {
 	absOutputDir, err := filepath.Abs(filepath.Dir(filepath.FromSlash(outputDir)))
 	if err != nil {
 		return fmt.Errorf("output %s: get absolute path: %w", outputDir, err)
@@ -37,7 +38,7 @@ func Bundle(ctx context.Context, schema *Schema, outputDir, bundleRoot string, w
 	defer closeIgnoreError(root)
 
 	loader := k8sAliasLoader{
-		inner:       NewDefaultLoader(http.DefaultClient, (*RootFS)(root), bundleRootAbs),
+		inner:       NewDefaultLoader(http.DefaultClient, (*RootFS)(root), bundleRootAbs, cacheMinDuration),
 		urlTemplate: k8sSchemaURL,
 		version:     k8sSchemaVersion,
 	}

--- a/pkg/cmd.go
+++ b/pkg/cmd.go
@@ -76,6 +76,7 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().Bool("bundle", false, "Bundle referenced ($ref) subschemas into a single file inside $defs")
 	cmd.Flags().Bool("bundle-without-id", false, "Bundle without using $id to reference bundled schemas, which improves compatibility with e.g the VS Code JSON extension")
 	cmd.Flags().String("bundle-root", "", "Root directory to allow local referenced files to be loaded from (default current working directory)")
+	cmd.Flags().String("bundle-cache-min", "", "Minimum cache duration for downloaded schemas, e.g. 24h or 30m. Raises short server Cache-Control max-age values; empty follows the server")
 
 	cmd.Flags().String("k8s-schema-url", DefaultConfig.K8sSchemaURL, "URL template used in $ref: $k8s/... alias")
 	cmd.Flags().String("k8s-schema-version", "", "Version used in the --k8s-schema-url template for $ref: $k8s/... alias")
@@ -179,6 +180,7 @@ type Config struct {
 	Bundle                 bool     `yaml:"bundle" koanf:"bundle"`
 	BundleRoot             string   `yaml:"bundleRoot" koanf:"bundle-root"`
 	BundleWithoutID        bool     `yaml:"bundleWithoutID" koanf:"bundle-without-id"`
+	BundleCacheMin         string   `yaml:"bundleCacheMin" koanf:"bundle-cache-min"`
 
 	K8sSchemaURL     string `yaml:"k8sSchemaURL" koanf:"k8s-schema-url"`
 	K8sSchemaVersion string `yaml:"k8sSchemaVersion" koanf:"k8s-schema-version"`

--- a/pkg/cmd_bundle.go
+++ b/pkg/cmd_bundle.go
@@ -60,6 +60,7 @@ func newBundleCmd() *cobra.Command {
 	cmd.Flags().IntVar(&opts.Indent, "indent", DefaultConfig.Indent, "Indentation spaces (even number)")
 	cmd.Flags().StringVar(&opts.BundleRoot, "bundle-root", "", "Root directory to allow local referenced files to be loaded from (default current working directory)")
 	cmd.Flags().BoolVar(&opts.BundleWithoutID, "bundle-without-id", false, "Bundle without using $id to reference bundled schemas, which improves compatibility with e.g the VS Code JSON extension")
+	cmd.Flags().StringVar(&opts.CacheMin, "bundle-cache-min", "", "Minimum cache duration for downloaded schemas, e.g. 24h or 30m. Raises short server Cache-Control max-age values; empty follows the server")
 	cmd.Flags().StringVar(&opts.K8sSchemaURL, "k8s-schema-url", DefaultConfig.K8sSchemaURL, "URL template used in $ref: $k8s/... alias")
 	cmd.Flags().StringVar(&opts.K8sSchemaVersion, "k8s-schema-version", "", "Version used in the --k8s-schema-url template for $ref: $k8s/... alias")
 
@@ -78,6 +79,10 @@ type BundleFileOptions struct {
 	BundleWithoutID  bool
 	K8sSchemaURL     string
 	K8sSchemaVersion string
+	// CacheMin is the raw --bundle-cache-min value (e.g. "24h"); it is parsed by
+	// [ParseCacheMinDuration] and passed through to [Bundle] to raise the minimum
+	// cache duration for downloaded schemas. An empty string means no override.
+	CacheMin string
 }
 
 // BundleFile reads the JSON schema file referenced by opts.InputFile, bundles
@@ -89,6 +94,11 @@ func BundleFile(ctx context.Context, out io.Writer, opts BundleFileOptions) erro
 	}
 	if opts.Indent%2 != 0 {
 		return errors.New("indentation must be an even number")
+	}
+
+	cacheMinDuration, err := ParseCacheMinDuration(opts.CacheMin)
+	if err != nil {
+		return err
 	}
 
 	content, err := os.ReadFile(filepath.Clean(opts.InputFile))
@@ -112,7 +122,7 @@ func BundleFile(ctx context.Context, out io.Writer, opts BundleFileOptions) erro
 	// the filename internally to derive the directory used as the cosmetic base
 	// for relative $ref/$id paths. Passing the input file path makes those paths
 	// relative to the schema file's own directory, matching the generate command.
-	if err := Bundle(ctx, &schema, inputAbs, opts.BundleRoot, opts.BundleWithoutID, opts.K8sSchemaURL, opts.K8sSchemaVersion); err != nil {
+	if err := Bundle(ctx, &schema, inputAbs, opts.BundleRoot, opts.BundleWithoutID, opts.K8sSchemaURL, opts.K8sSchemaVersion, cacheMinDuration); err != nil {
 		return err
 	}
 

--- a/pkg/cmd_bundle_test.go
+++ b/pkg/cmd_bundle_test.go
@@ -140,6 +140,17 @@ func TestBundleFile_IndentValidation(t *testing.T) {
 	}
 }
 
+func TestBundleFile_CacheMinValidation(t *testing.T) {
+	var buf bytes.Buffer
+	err := BundleFile(context.Background(), &buf, BundleFileOptions{
+		InputFile: "../testdata/bundle/cmd.schema.json",
+		Indent:    DefaultConfig.Indent,
+		CacheMin:  "not-a-duration",
+	})
+	assert.ErrorContains(t, err, "parse bundle cache min duration")
+	assert.Empty(t, buf.String())
+}
+
 // errWriter always fails, used to exercise the output write error path.
 type errWriter struct{}
 

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -124,7 +124,11 @@ func buildJSONSchema(ctx context.Context, config *Config) (*Schema, error) {
 	}
 
 	if config.Bundle {
-		if err := Bundle(ctx, mergedSchema, config.Output, config.BundleRoot, config.BundleWithoutID, config.K8sSchemaURL, config.K8sSchemaVersion); err != nil {
+		cacheMinDuration, err := ParseCacheMinDuration(config.BundleCacheMin)
+		if err != nil {
+			return nil, err
+		}
+		if err := Bundle(ctx, mergedSchema, config.Output, config.BundleRoot, config.BundleWithoutID, config.K8sSchemaURL, config.K8sSchemaVersion, cacheMinDuration); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -484,6 +484,21 @@ func TestGenerateJsonSchema_Errors(t *testing.T) {
 			expectedErr: errors.New("write output schema:"),
 		},
 		{
+			name: "bundle invalid cache min duration",
+			config: &Config{
+				Draft:          2020,
+				Indent:         4,
+				Bundle:         true,
+				BundleRoot:     "..",
+				BundleCacheMin: "not-a-duration",
+				Values: []string{
+					"../testdata/bundle/simple.yaml",
+				},
+				Output: "../testdata/bundle_output.json",
+			},
+			expectedErr: errors.New("parse bundle cache min duration"),
+		},
+		{
 			name: "bundle invalid root path",
 			config: &Config{
 				Draft:      2020,

--- a/pkg/httpcache.go
+++ b/pkg/httpcache.go
@@ -47,6 +47,9 @@ func NewHTTPMemoryCache() *HTTPMemoryCache {
 type HTTPMemoryCache struct {
 	Map map[string]CachedResponse
 	Now func() time.Time
+
+	// MinCacheDuration mirrors [HTTPFileCache.MinCacheDuration].
+	MinCacheDuration time.Duration
 }
 
 var _ HTTPCache = &HTTPMemoryCache{}
@@ -64,6 +67,7 @@ func (h *HTTPMemoryCache) SaveCache(req *http.Request, resp *http.Response, body
 		// Response doesn't want to be cached.
 		return CachedResponse{}, nil
 	}
+	maxAge = applyMinCacheDuration(maxAge, h.MinCacheDuration)
 	cached := CachedResponse{
 		Data:     body,
 		CachedAt: h.Now(),
@@ -77,9 +81,15 @@ func (h *HTTPMemoryCache) SaveCache(req *http.Request, resp *http.Response, body
 type HTTPFileCache struct {
 	cacheDirFunc func() string
 	now          func() time.Time
+
+	// MinCacheDuration, when greater than zero, raises a cacheable response's
+	// effective max-age to at least this value. It lets users keep downloaded
+	// schemas cached longer than the short max-age that many schema stores
+	// return. Responses the server marks as uncacheable are still not cached.
+	MinCacheDuration time.Duration
 }
 
-func NewHTTPCache() *HTTPFileCache {
+func NewHTTPCache(minCacheDuration time.Duration) *HTTPFileCache {
 	return &HTTPFileCache{
 		cacheDirFunc: sync.OnceValue(func() string {
 			dir, err := os.UserCacheDir()
@@ -89,7 +99,8 @@ func NewHTTPCache() *HTTPFileCache {
 			}
 			return filepath.Join(dir, "helm-values-schema-json", "httploader")
 		}),
-		now: time.Now,
+		now:              time.Now,
+		MinCacheDuration: minCacheDuration,
 	}
 }
 
@@ -124,6 +135,7 @@ func (h *HTTPFileCache) SaveCache(req *http.Request, resp *http.Response, body [
 		return CachedResponse{}, nil
 	}
 
+	maxAge = applyMinCacheDuration(maxAge, h.MinCacheDuration)
 	cached := CachedResponse{
 		Data:     body,
 		CachedAt: h.now().UTC(),
@@ -163,6 +175,35 @@ func getCacheControlMaxAge(header string) time.Duration {
 		}
 	}
 	return maxAge
+}
+
+// applyMinCacheDuration raises maxAge to minDuration when minDuration is larger.
+// It is only meant to be called for responses that are already cacheable
+// (maxAge > 0); responses the server marked as no-store/no-cache are skipped by
+// the caller and never extended.
+func applyMinCacheDuration(maxAge, minDuration time.Duration) time.Duration {
+	if minDuration > maxAge {
+		return minDuration
+	}
+	return maxAge
+}
+
+// ParseCacheMinDuration parses a --bundle-cache-min value such as "24h" or
+// "30m" into a [time.Duration]. An empty string means "no override" and returns
+// zero. It is the single place that interprets the duration string, so any
+// future support for extended units (1d/1w/1M/1y) only needs to be added here.
+func ParseCacheMinDuration(s string) (time.Duration, error) {
+	if s == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("parse bundle cache min duration %q: %w", s, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("bundle cache min duration %q must not be negative", s)
+	}
+	return d, nil
 }
 
 // urlToCachePath returns a relative path that can be used as a file path

--- a/pkg/httpcache_test.go
+++ b/pkg/httpcache_test.go
@@ -21,7 +21,7 @@ func TestHTTPCache_CacheDir(t *testing.T) {
 	os.Clearenv()
 	require.NoError(t, os.Setenv("HOME", "/foo/bar"))
 
-	cache := NewHTTPCache()
+	cache := NewHTTPCache(0)
 
 	dir := cache.cacheDirFunc()
 	require.Contains(t, dir, filepath.FromSlash("/helm-values-schema-json/httploader"))
@@ -32,7 +32,7 @@ func TestHTTPCache_CacheDir_Error(t *testing.T) {
 	// Remove $HOME and $XDG_CONFIG_DIR, which makes [os.UserCacheDir] fail
 	os.Clearenv()
 
-	cache := NewHTTPCache()
+	cache := NewHTTPCache(0)
 	dir := cache.cacheDirFunc()
 	require.Contains(t, dir, filepath.FromSlash("/helm-values-schema-json/httploader"))
 }
@@ -139,7 +139,7 @@ func TestLoadCache(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cache := NewHTTPCache()
+			cache := NewHTTPCache(0)
 			dir, err := os.MkdirTemp("", "schema-httpcache-*")
 			require.NoError(t, err)
 			t.Cleanup(func() {
@@ -234,7 +234,7 @@ func TestSaveCache(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cache := NewHTTPCache()
+			cache := NewHTTPCache(0)
 			dir := testutil.CreateTempDir(t, "schema-httpcache-*")
 			cache.cacheDirFunc = func() string { return dir }
 			cache.now = func() time.Time { return now }
@@ -257,7 +257,7 @@ func TestSaveCache(t *testing.T) {
 
 func TestSaveCache_Error(t *testing.T) {
 	t.Run("mkdir", func(t *testing.T) {
-		cache := NewHTTPCache()
+		cache := NewHTTPCache(0)
 		file := testutil.CreateTempFile(t, "schema-httpcache-*")
 		cache.cacheDirFunc = func() string { return file.Name() }
 
@@ -274,7 +274,7 @@ func TestSaveCache_Error(t *testing.T) {
 	})
 
 	t.Run("create file", func(t *testing.T) {
-		cache := NewHTTPCache()
+		cache := NewHTTPCache(0)
 		dir := testutil.CreateTempDir(t, "schema-httpcache-*")
 		cache.cacheDirFunc = func() string { return dir }
 
@@ -291,6 +291,122 @@ func TestSaveCache_Error(t *testing.T) {
 		}, nil)
 		assert.ErrorContains(t, err, "create cache file:")
 	})
+}
+
+func TestSaveCache_MinCacheDuration(t *testing.T) {
+	now := time.Date(2025, 6, 9, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		minDuration time.Duration
+		cacheCtrl   string
+		want        CachedResponse
+	}{
+		{
+			name:        "raises short max-age to the minimum",
+			minDuration: 24 * time.Hour,
+			cacheCtrl:   "max-age=300",
+			want: CachedResponse{
+				CachedAt: now,
+				MaxAge:   24 * time.Hour,
+				Data:     []byte("foo"),
+			},
+		},
+		{
+			name:        "keeps longer max-age untouched",
+			minDuration: time.Hour,
+			cacheCtrl:   "max-age=7200",
+			want: CachedResponse{
+				CachedAt: now,
+				MaxAge:   2 * time.Hour,
+				Data:     []byte("foo"),
+			},
+		},
+		{
+			name:        "does not cache no-store responses",
+			minDuration: 24 * time.Hour,
+			cacheCtrl:   "no-store",
+			want:        CachedResponse{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{
+				Header: http.Header{
+					http.CanonicalHeaderKey("Cache-Control"): []string{tt.cacheCtrl},
+				},
+			}
+			req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+			require.NoError(t, err)
+
+			t.Run("file", func(t *testing.T) {
+				dir := testutil.CreateTempDir(t, "schema-httpcache-*")
+				cache := NewHTTPCache(tt.minDuration)
+				cache.cacheDirFunc = func() string { return dir }
+				cache.now = func() time.Time { return now }
+
+				cached, err := cache.SaveCache(req, resp, []byte("foo"))
+				require.NoError(t, err)
+				testutil.Equal(t, tt.want, cached)
+			})
+
+			t.Run("memory", func(t *testing.T) {
+				cache := NewHTTPMemoryCache()
+				cache.MinCacheDuration = tt.minDuration
+				cache.Now = func() time.Time { return now }
+
+				cached, err := cache.SaveCache(req, resp, []byte("foo"))
+				require.NoError(t, err)
+				testutil.Equal(t, tt.want, cached)
+			})
+		})
+	}
+}
+
+func TestApplyMinCacheDuration(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxAge      time.Duration
+		minDuration time.Duration
+		want        time.Duration
+	}{
+		{name: "min larger than max-age", maxAge: 5 * time.Minute, minDuration: time.Hour, want: time.Hour},
+		{name: "min smaller than max-age", maxAge: 2 * time.Hour, minDuration: time.Hour, want: 2 * time.Hour},
+		{name: "min equal to max-age", maxAge: time.Hour, minDuration: time.Hour, want: time.Hour},
+		{name: "min disabled (zero)", maxAge: 5 * time.Minute, minDuration: 0, want: 5 * time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, applyMinCacheDuration(tt.maxAge, tt.minDuration))
+		})
+	}
+}
+
+func TestParseCacheMinDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Duration
+		wantErr string
+	}{
+		{name: "empty is no override", input: "", want: 0},
+		{name: "hours", input: "24h", want: 24 * time.Hour},
+		{name: "minutes", input: "30m", want: 30 * time.Minute},
+		{name: "combined", input: "1h30m", want: 90 * time.Minute},
+		{name: "invalid", input: "tomorrow", wantErr: "parse bundle cache min duration"},
+		{name: "negative", input: "-1h", wantErr: "must not be negative"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseCacheMinDuration(tt.input)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestGetCacheControlMaxAge(t *testing.T) {

--- a/pkg/loader.go
+++ b/pkg/loader.go
@@ -45,9 +45,9 @@ func (r *RootFS) Open(name string) (fs.File, error) {
 	return ((*os.Root)(r)).Open(name)
 }
 
-func NewDefaultLoader(client *http.Client, bundleFS fs.FS, basePath string) Loader {
+func NewDefaultLoader(client *http.Client, bundleFS fs.FS, basePath string, cacheMinDuration time.Duration) Loader {
 	fileLoader := NewFileLoader(bundleFS, basePath)
-	httpLoader := NewHTTPLoader(client, NewHTTPCache())
+	httpLoader := NewHTTPLoader(client, NewHTTPCache(cacheMinDuration))
 	return NewCacheLoader(URLSchemeLoader{
 		"http":  httpLoader,
 		"https": httpLoader,


### PR DESCRIPTION
Resolves #287.

Many schema stores return a short `Cache-Control` max-age (5 or 30 minutes), so bundled remote schemas are re-downloaded far more often than necessary. This adds a `--bundle-cache-min` flag (and a `bundleCacheMin` config field) that raises a cacheable response's effective max-age to at least the given duration.

## Behaviour

- `helm schema --bundle --bundle-cache-min 24h`, or `bundleCacheMin: "24h"` in `.schema.yaml`.
- Also available on the `helm schema bundle` subcommand.
- Uses Go's [duration syntax](https://pkg.go.dev/time#ParseDuration) (`24h`, `30m`, `1h30m`). An empty value (default) follows the server's caching headers.
- Applied in `HTTPCache.SaveCache` as `maxAge = max(maxAge, min)`. Responses the server marks `no-store`/`no-cache` are still never cached — the override only extends already-cacheable responses.

## Validation

- `make test-all` passes at 99.7% coverage. New unit tests cover `applyMinCacheDuration`, `ParseCacheMinDuration` (including invalid/negative input), the file + memory `SaveCache` override paths, and the generate/bundle error branches.
- `make check` (verify/tidy/fmt/vet) is clean; `golangci-lint run` reports 0 issues.
- `config.schema.json` was regenerated from `.schema.yaml` (its generated source); the README flag tables and `docs/README.md` were updated to match.

## Out of scope (possible follow-up)

The issue also floats a bonus for extended units (`1d`/`1w`/`1M`/`1y`) that `time.ParseDuration` does not support. I kept this PR to Go-native durations; `ParseCacheMinDuration` is intentionally the single seam where those units could be added later without touching the flag/config wiring.