### PR TITLE
feat: add nullable schema annotation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,7 @@ The following annotations are supported:
 * [Validation Keywords for Any Instance Type](#validation-keywords-for-any-instance-type)
     * [Type](#type)
     * [Multiple types](#multiple-types)
+    * [Nullable](#nullable)
     * [Enum](#enum)
     * [ItemEnum](#itemEnum)
     * [Const](#const)
@@ -174,6 +175,40 @@ app: &app
         }
     },
     "type": "object"
+}
+```
+
+### Nullable
+
+The `nullable` annotation is a shorthand that adds `null` to the value's type, so the value may also be omitted or set to `null`. It is semantically identical to listing `null` in [Multiple types](#multiple-types), but reuses the type inferred from the value instead of repeating it.
+
+```yaml
+# These two are equivalent:
+replicaCount: # @schema type:[integer, null]
+replicaCount: # @schema type: integer; nullable
+```
+
+```json
+"replicaCount": {
+    "type": [
+        "integer",
+        "null"
+    ]
+}
+```
+
+When no explicit `type` is given, `nullable` appends `null` to the type inferred from the YAML value:
+
+```yaml
+nameOverride: "" # @schema nullable
+```
+
+```json
+"nameOverride": {
+    "type": [
+        "string",
+        "null"
+    ]
 }
 ```
 

--- a/pkg/comment.go
+++ b/pkg/comment.go
@@ -143,6 +143,9 @@ func convertScalarsToString(slice []any) {
 }
 
 func processComment(schema *Schema, commentLines []string) error {
+	// nullable is applied after the loop so it merges "null" into the final
+	// type regardless of the order keywords appear in the comment.
+	var nullable bool
 	for key, value := range splitCommentsByParts(commentLines) {
 		switch key {
 		case "enum":
@@ -213,6 +216,10 @@ func processComment(schema *Schema, commentLines []string) error {
 			schema.Type = list
 			if len(list) == 1 {
 				schema.Type = list[0]
+			}
+		case "nullable":
+			if err := processBoolComment(&nullable, value); err != nil {
+				return fmt.Errorf("nullable: %w", err)
 			}
 		case "title":
 			schema.Title = value
@@ -316,7 +323,38 @@ func processComment(schema *Schema, commentLines []string) error {
 		}
 	}
 
+	if nullable {
+		schema.Type = appendNullType(schema.Type)
+	}
+
 	return nil
+}
+
+// appendNullType adds "null" to the schema type, turning a single type into a
+// list and leaving an existing "null" untouched. It backs the `nullable`
+// annotation, e.g. `# @schema nullable` on a string value yields
+// `"type": ["string", "null"]`.
+func appendNullType(t any) any {
+	switch v := t.(type) {
+	case nil:
+		return "null"
+	case string:
+		if v == "null" {
+			return v
+		}
+		return []any{v, "null"}
+	case []any:
+		// v is the freshly built type list owned solely by schema.Type, so
+		// appending in place is safe.
+		for _, item := range v {
+			if s, ok := item.(string); ok && s == "null" {
+				return v
+			}
+		}
+		return append(v, "null")
+	default:
+		return t
+	}
 }
 
 func processObjectComment[T any](dest *T, comment string) error {

--- a/pkg/comment_test.go
+++ b/pkg/comment_test.go
@@ -658,6 +658,48 @@ func TestProcessComment(t *testing.T) {
 			comment:    "# @schema examples:[foo, bar]",
 			wantSchema: &Schema{Examples: []any{"foo", "bar"}},
 		},
+		{
+			name:       "nullable on inferred scalar type",
+			schema:     &Schema{Type: "string"},
+			comment:    "# @schema nullable",
+			wantSchema: &Schema{Type: []any{"string", "null"}},
+		},
+		{
+			name:       "nullable without a type",
+			schema:     &Schema{},
+			comment:    "# @schema nullable",
+			wantSchema: &Schema{Type: "null"},
+		},
+		{
+			name:       "nullable on an already-null type",
+			schema:     &Schema{Type: "null"},
+			comment:    "# @schema nullable",
+			wantSchema: &Schema{Type: "null"},
+		},
+		{
+			name:       "nullable combined with explicit type",
+			schema:     &Schema{},
+			comment:    "# @schema nullable; type: integer",
+			wantSchema: &Schema{Type: []any{"integer", "null"}},
+		},
+		{
+			name:       "nullable appends to a type list",
+			schema:     &Schema{},
+			comment:    "# @schema type:[string, integer]; nullable",
+			wantSchema: &Schema{Type: []any{"string", "integer", "null"}},
+		},
+		{
+			name:       "nullable is idempotent when null already present",
+			schema:     &Schema{},
+			comment:    "# @schema type:[string, null]; nullable",
+			wantSchema: &Schema{Type: []any{"string", "null"}},
+		},
+		{
+			name:       "nullable false leaves the type untouched",
+			schema:     &Schema{Type: "string"},
+			comment:    "# @schema nullable: false",
+			wantSchema: &Schema{Type: "string"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -665,6 +707,27 @@ func TestProcessComment(t *testing.T) {
 			err := processComment(tt.schema, []string{tt.comment})
 			require.NoError(t, err)
 			testutil.Equal(t, tt.wantSchema, tt.schema)
+		})
+	}
+}
+
+func TestAppendNullType(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want any
+	}{
+		{name: "nil", in: nil, want: "null"},
+		{name: "scalar string", in: "string", want: []any{"string", "null"}},
+		{name: "already null", in: "null", want: "null"},
+		{name: "list without null", in: []any{"string", "integer"}, want: []any{"string", "integer", "null"}},
+		{name: "list with null", in: []any{"string", "null"}, want: []any{"string", "null"}},
+		{name: "unsupported type is returned as-is", in: 42, want: 42},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutil.Equal(t, tt.want, appendNullType(tt.in))
 		})
 	}
 }
@@ -685,6 +748,7 @@ func TestProcessComment_Error(t *testing.T) {
 		{name: "uniqueItems invalid bool", comment: "# @schema uniqueItems: foo", wantErr: "uniqueItems: invalid boolean"},
 		{name: "skipProperties invalid bool", comment: "# @schema skipProperties: foo", wantErr: "skipProperties: invalid boolean"},
 		{name: "mergeProperties invalid bool", comment: "# @schema mergeProperties: foo", wantErr: "mergeProperties: invalid boolean"},
+		{name: "nullable invalid bool", comment: "# @schema nullable: foo", wantErr: "nullable: invalid boolean"},
 
 		{name: "maxLength invalid uint64", comment: "# @schema maxLength: foo", wantErr: "maxLength: invalid integer"},
 		{name: "minLength invalid uint64", comment: "# @schema minLength: foo", wantErr: "minLength: invalid integer"},


### PR DESCRIPTION
Closes #248.

Adds a `nullable` meta-keyword that is a shorthand for adding `null` to a value's type, so you can write `# @schema nullable` instead of repeating the inferred type in `# @schema type: [string, null]`.

```yaml
nameOverride: "" # @schema nullable
# => "type": ["string", "null"]

replicaCount: # @schema type: integer; nullable
# => "type": ["integer", "null"]
```

It is applied after the comment keyword loop, so it merges `null` into the final type regardless of the order keywords appear in the comment (the keyword map iterates in non-deterministic order). It is idempotent when `null` is already present, and `nullable: false` is a no-op.

Validation:
- `go test ./...` — all packages pass
- `gofmt -l pkg/` and `go vet ./pkg/` — clean
- New code coverage: `processComment` and `appendNullType` both 100% (table tests for nil / scalar / list / already-null / both keyword orderings / `false` opt-out / invalid bool)
- `docs/README.md` updated with a `### Nullable` section + TOC entry

Note: item-level `items/nullable` (mentioned in #248 as combining with #247) is intentionally left as a follow-up to keep this PR a single reviewable slice.