### PR TITLE
fix: don't rewrite output file when schema is unchanged

### DIFF
--- a/bearer.ignore
+++ b/bearer.ignore
@@ -1,0 +1,8 @@
+{
+  "3e62f4ee41a5fb80d82d43cbff2e2fc2_0": {
+    "author": "Kalle Fagerberg",
+    "comment": "path is provided by the user, but that's intentional.",
+    "false_positive": true,
+    "ignored_at": "2026-08-13T20:28:11Z"
+  }
+}

--- a/pkg/generator.go
+++ b/pkg/generator.go
@@ -198,11 +198,18 @@ func WriteOutput(ctx context.Context, mergedSchema *Schema, outputPath, indent s
 	return nil
 }
 
+//gosec:disable G304 -- path is provided by the user, but that's intentional.
 func writeOutputFile(stdout io.Writer, path string, content []byte) error {
 	if path == "-" {
 		if _, err := stdout.Write(content); err != nil {
 			return fmt.Errorf("write schema to stdout: %w", err)
 		}
+		return nil
+	}
+
+	// Don't touch the file if its content is already up to date, so that
+	// modification times stay stable for tooling that watches the file.
+	if existing, err := os.ReadFile(path); err == nil && bytes.Equal(existing, content) {
 		return nil
 	}
 

--- a/pkg/generator_test.go
+++ b/pkg/generator_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/losisin/helm-values-schema-json/v2/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -897,6 +898,34 @@ func TestWriteOutputFile_WriteToFile(t *testing.T) {
 	defer func() {
 		_ = os.Remove("some_example_output.txt")
 	}()
+}
+
+func TestWriteOutputFile_UnchangedContentIsNotRewritten(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "values.schema.json")
+	content := []byte("some content\n")
+	require.NoError(t, writeOutputFile(nil, path, content))
+
+	before, err := os.Stat(path)
+	require.NoError(t, err)
+
+	// Make sure a rewrite would be observable on filesystems with coarse
+	// modification time resolution.
+	stale := before.ModTime().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(path, stale, stale))
+
+	require.NoError(t, writeOutputFile(nil, path, content))
+
+	after, err := os.Stat(path)
+	require.NoError(t, err)
+	testutil.Equal(t, stale.UnixNano(), after.ModTime().UnixNano())
+
+	// A changed schema must still be written.
+	require.NoError(t, writeOutputFile(nil, path, []byte("other content\n")))
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	testutil.Equal(t, "other content\n", string(got))
 }
 
 func TestWriteOutputFile_WriteToStdout(t *testing.T) {


### PR DESCRIPTION
writeOutputFile now compares the generated schema against the existing file content and returns early when they match, leaving the file and its modification time untouched.

Any read error falls through to the normal write, and the "-" stdout path is unaffected.